### PR TITLE
Fix broken colors in Catppuccin Mocha

### DIFF
--- a/themes/catppuccin-mocha.sh
+++ b/themes/catppuccin-mocha.sh
@@ -19,8 +19,8 @@ export COLOR_14="#F5C2E7"           # Light Magenta
 export COLOR_15="#94E2D5"           # Light Cyan
 export COLOR_16="#A6ADC8"           # White
 
-export BACKGROUND_COLOR="#"   # Background Color
-export FOREGROUND_COLOR="#"   # Foreground Color (text)
+export BACKGROUND_COLOR="#1e1e2e"   # Background Color
+export FOREGROUND_COLOR="#cdd6f4"   # Foreground Color (text)
 export CURSOR_COLOR="$FOREGROUND_COLOR" # Cursor color
 export PROFILE_NAME="Catppuccin Mocha"
 # =============================================================== #


### PR DESCRIPTION
themes.json isn't fully parseable in wezterm's import machinery because of these broken color definitions:

```json
    {
      "name": "CatppuccinMocha",
      "black": "#45475A",
      "red": "#F38BA8",
      "green": "#A6E3A1",
      "yellow": "#F9E2AF",
      "blue": "#89B4FA",
      "purple": "#F5C2E7",
      "cyan": "#94E2D5",
      "white": "#BAC2DE",
      "brightBlack": "#585B70",
      "brightRed": "#F38BA8",
      "brightGreen": "#A6E3A1",
      "brightYellow": "#F9E2AF",
      "brightBlue": "#89B4FA",
      "brightPurple": "#F5C2E7",
      "brightCyan": "#94E2D5",
      "brightWhite": "#A6ADC8",
      "foreground": "#",
      "background": "#",
      "cursorColor": "#"
    },
```


Colors are inserted here based on the upstream:
https://github.com/catppuccin/wezterm/blob/main/dist/catppuccin-mocha.toml#L12 https://github.com/catppuccin/wezterm/blob/main/dist/catppuccin-mocha.toml#L27

