### PR TITLE
Add Gruvbox Material (dark medium) theme

### DIFF
--- a/gogh.sh
+++ b/gogh.sh
@@ -98,6 +98,7 @@ declare -a THEMES=(
   'grape.sh'
   'grass.sh'
   'gruvbox-dark.sh'
+  'gruvbox-material.sh'
   'gruvbox.sh'
   'hardcore.sh'
   'harper.sh'

--- a/installs/gruvbox-material.sh
+++ b/installs/gruvbox-material.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+export PROFILE_NAME="Gruvbox Material"
+
+export COLOR_01="#3C3836"           # Black (Host)
+export COLOR_02="#EA6962"           # Red (Syntax string)
+export COLOR_03="#A9B665"           # Green (Command)
+export COLOR_04="#D8A657"           # Yellow (Command second)
+export COLOR_05="#7DAEA3"           # Blue (Path)
+export COLOR_06="#D3869B"           # Magenta (Syntax var)
+export COLOR_07="#89B482"           # Cyan (Prompt)
+export COLOR_08="#D4BE98"           # White
+
+export COLOR_09="#3C3836"           # Bright Black
+export COLOR_10="#EA6962"           # Bright Red (Command error)
+export COLOR_11="#A9B665"           # Bright Green (Exec)
+export COLOR_12="#D8A657"           # Bright Yellow
+export COLOR_13="#7DAEA3"           # Bright Blue (Folder)
+export COLOR_14="#D3869B"           # Bright Magenta
+export COLOR_15="#89B482"           # Bright Cyan
+export COLOR_16="#D4BE98"           # Bright White
+
+export BACKGROUND_COLOR="#282828"   # Background
+export FOREGROUND_COLOR="#D4BE98"   # Foreground (Text)
+
+export CURSOR_COLOR="#D4BE98" # Cursor
+
+# | ===========================================================================
+# | Apply Colors
+# | ===========================================================================
+SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
+
+# Allow developer to change url to forked url for easier testing
+# IMPORTANT: Make sure you export this variable if your main shell is not bash
+BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
+
+
+if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+  bash "${PARENT_PATH}/apply-colors.sh"
+else
+  if [[ "$(uname)" = "Darwin" ]]; then
+    # OSX ships with curl and ancient bash
+    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
+  else
+    # Linux ships with wget
+    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
+  fi
+fi

--- a/themes/Gruvbox Material.yml
+++ b/themes/Gruvbox Material.yml
@@ -1,0 +1,25 @@
+---
+name: 'Gruvbox Material'
+
+color_01: '#3C3836'    # Black (Host)
+color_02: '#EA6962'    # Red (Syntax string)
+color_03: '#A9B665'    # Green (Command)
+color_04: '#D8A657'    # Yellow (Command second)
+color_05: '#7DAEA3'    # Blue (Path)
+color_06: '#D3869B'    # Magenta (Syntax var)
+color_07: '#89B482'    # Cyan (Prompt)
+color_08: '#D4BE98'    # White
+
+color_09: '#3C3836'    # Bright Black
+color_10: '#EA6962'    # Bright Red (Command error)
+color_11: '#A9B665'    # Bright Green (Exec)
+color_12: '#D8A657'    # Bright Yellow
+color_13: '#7DAEA3'    # Bright Blue (Folder)
+color_14: '#D3869B'    # Bright Magenta
+color_15: '#89B482'    # Bright Cyan
+color_16: '#D4BE98'    # Bright White
+
+background: '#282828'  # Background
+foreground: '#D4BE98'  # Foreground (Text)
+
+cursor: '#D4BE98'      # Cursor


### PR DESCRIPTION
Added Gruvbox Material (dark medium) theme. Adapted from the original author theme for Alacrity [here](https://gist.github.com/sainnhe/ad5cbc4f05c4ced83f80e54d9a75d22f)