### PR TITLE
Update background color of Everforest Dark theme

### DIFF
--- a/themes/Everforest Dark.yml
+++ b/themes/Everforest Dark.yml
@@ -19,7 +19,7 @@ color_14: '#DF69BA'    # Bright Magenta
 color_15: '#35A77C'    # Bright Cyan
 color_16: '#DFDDC8'    # Bright White
 
-background: '#2F383E'  # Background
+background: '#2D353B'  # Background
 foreground: '#D3C6AA'  # Foreground (Text)
 
 cursor: '#D3C6AA'      # Cursor


### PR DESCRIPTION
Sync with upstream changes: https://github.com/sainnhe/everforest/compare/d855af5434...81041b4033

No changes to foreground colors seem required.

---

Preview:

![before][before]![now][now]

[before]: https://fakeimg.pl/96/2F383E/D3C6AA/?text=before "before"
[now]: https://fakeimg.pl/96/2D353B/D3C6AA/?text=now "now"