### PR TITLE
Fix alacritty config path mismatch with it's doc

### DIFF
--- a/apply-alacritty.py
+++ b/apply-alacritty.py
@@ -34,10 +34,10 @@ def get_conf_path():
         home = os.getenv('HOME')
         if home is not None and os.path.exists(home + '/.config/alacritty/alacritty.yml'):
             return home + "/.config/alacritty/alacritty.yml"
-        if home is not None and os.path.exists(home + '/.config/alacritty.yml'):
-            return home + "/.config/alacritty.yml"
-        if home is not None and os.path.exists(home + 'alacritty.yml'):
-            return home + "/alacritty.yml"
+        if home is not None and os.path.exists(home + '/.config/alacritty/alacritty.yml'):
+            return home + "/.config/alacritty/alacritty.yml"
+        if home is not None and os.path.exists(home + '/.alacritty.yml'):
+            return home + "/.alacritty.yml"
 
     print("Could not find alacritty config file\nPlease make sure you have a file in one of the paths specified on\nhttps://github.com/alacritty/alacritty#configuration")
     sys.exit(1)


### PR DESCRIPTION
According to https://github.com/alacritty/alacritty/tree/master#configuration, the configure file should be in following path

1. $XDG_CONFIG_HOME/alacritty/alacritty.yml
2. $XDG_CONFIG_HOME/alacritty.yml
3. $HOME/.config/alacritty/alacritty.yml
4. $HOME/.alacritty.yml

but paths in script do not fully match these paths, this patch fix this problem.