### PR TITLE
Added support for Linux virtual terminal.

### DIFF
--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -1024,7 +1024,7 @@ case "${TERMINAL}" in
 
   * )
     printf '%s\n'                                             \
-    "Unsupported terminal ${TERMINAL}!"                       \
+    "Unsupported terminal!"                                   \
     ""                                                        \
     "Supported terminals:"                                    \
     "   mintty and deriviates"                                \

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -894,7 +894,12 @@ apply_xfce4-terminal() {
 }
 
 apply_linux_vt () {
-  local theme_dir=~/.vtrgb-gogh
+  local theme_dir
+  if [[ "${USER}" == "root" ]]; then
+    theme_dir=/usr/local/share/vtrgb-gogh
+  else
+    theme_dir=~/.vtrgb-gogh
+  fi
   mkdir -p "${theme_dir}"
   local file_name=${theme_dir}/${PROFILE_NAME}
   if [[ ! -f ${file_name} ]]; then
@@ -903,6 +908,10 @@ apply_linux_vt () {
 	    local color=COLOR_${c}
 	    echo "${!color}" >> "${file_name}"
 	  done
+  fi
+
+  if [[ "${USER}" == "root" ]]; then
+    update-alternatives --install /etc/vtrgb vtrgb "${file_name}" 30
   fi
 }
 

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -893,8 +893,8 @@ apply_xfce4-terminal() {
     exit 0
 }
 
-apply_linux () {
-  local theme_dir=~/.setvtrgb-themes
+apply_linux_vt () {
+  local theme_dir=~/.vtrgb-gogh
   mkdir -p "${theme_dir}"
   local file_name=${theme_dir}/${PROFILE_NAME}
   if [[ ! -f ${file_name} ]]; then
@@ -1007,7 +1007,7 @@ case "${TERMINAL}" in
     ;;
 
   login )
-    apply_linux
+    apply_linux_vt
     ;;
 
   * )

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -59,6 +59,8 @@ if [[ -z "${TERMINAL:-}" ]]; then
     TERMINAL=$TERM_PROGRAM
   elif [[ "${OS#CYGWIN}" != "${OS}" ]]; then
     TERMINAL="mintty"
+  elif [[ "${TERM}" = "linux" ]]; then
+    TERMINAL="linux"
   else
     # |
     # | Depending on how the script was invoked, we need
@@ -1015,13 +1017,13 @@ case "${TERMINAL}" in
     apply_konsole
     ;;
 
-  login )
+  linux )
     apply_linux_vt
     ;;
 
   * )
     printf '%s\n'                                             \
-    "Unsupported terminal!"                                   \
+    "Unsupported terminal ${TERMINAL}!"                       \
     ""                                                        \
     "Supported terminals:"                                    \
     "   mintty and deriviates"                                \

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -897,12 +897,13 @@ apply_xfce4-terminal() {
 
 apply_linux_vt () {
   local theme_dir
-  if [[ "${USER}" == "root" ]]; then
+  if [[ "${USER}" = "root" ]]; then
     theme_dir=/usr/local/share/vtrgb-gogh
   else
     theme_dir=~/.vtrgb-gogh
   fi
   mkdir -p "${theme_dir}"
+
   local file_name=${theme_dir}/${PROFILE_NAME}
   if [[ ! -f ${file_name} ]]; then
     touch "${file_name}"
@@ -912,7 +913,7 @@ apply_linux_vt () {
 	  done
   fi
 
-  if [[ "${USER}" == "root" ]]; then
+  if [[ "${USER}" = "root" ]]; then
     update-alternatives --install /etc/vtrgb vtrgb "${file_name}" 30
   fi
 }
@@ -1037,6 +1038,7 @@ case "${TERMINAL}" in
     "   foot"                                                 \
     "   kitty"                                                \
     "   konsole"                                              \
+    "   linux"
     ""                                                        \
     "If you believe you have received this message in error," \
     "try manually setting \`TERMINAL', hint: ps -h -o comm -p \$PPID"

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -1038,7 +1038,7 @@ case "${TERMINAL}" in
     "   foot"                                                 \
     "   kitty"                                                \
     "   konsole"                                              \
-    "   linux"
+    "   linux"                                                \
     ""                                                        \
     "If you believe you have received this message in error," \
     "try manually setting \`TERMINAL', hint: ps -h -o comm -p \$PPID"

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -913,7 +913,7 @@ apply_linux_vt () {
 	  done
   fi
 
-  if [[ "${USER}" = "root" ]]; then
+  if command -v update-alternatives >/dev/null &2>&1 && [[ "${USER}" = "root" ]]; then
     update-alternatives --install /etc/vtrgb vtrgb "${file_name}" 30
   fi
 }

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -893,6 +893,19 @@ apply_xfce4-terminal() {
     exit 0
 }
 
+apply_linux () {
+  local theme_dir=~/.setvtrgb-themes
+  mkdir -p "${theme_dir}"
+  local file_name=${theme_dir}/${PROFILE_NAME}
+  if [[ ! -f ${file_name} ]]; then
+    touch "${file_name}"
+	  for c in $(seq -s " " -w 16); do
+	    local color=COLOR_${c}
+	    echo "${!color}" >> "${file_name}"
+	  done
+  fi
+}
+
 [[ -n "${UUIDGEN}" ]] && PROFILE_SLUG="$(uuidgen)"
 
 case "${TERMINAL}" in
@@ -991,6 +1004,10 @@ case "${TERMINAL}" in
 
   konsole )
     apply_konsole
+    ;;
+
+  login )
+    apply_linux
     ;;
 
   * )

--- a/gogh.sh
+++ b/gogh.sh
@@ -395,6 +395,8 @@ if [[ -z "${TERMINAL:-}" ]]; then
     TERMINAL="mintty"
   elif [[ "$TERM" = "xterm-kitty" ]]; then
     TERMINAL="kitty"
+  elif [[ "${TERM}" = "linux" ]]; then
+    TERMINAL="linux"
   else
     # |
     # | Depending on how the script was invoked, we need


### PR DESCRIPTION
Added support for Linux virtual terminals.

Themes are put in ~/.vtrgb-gogh when installed as a user. The colors can be set by calling setvtrgb. For example

> setvtrgb ~/.vtrgb-gogh/Tin

This can be done in your .bashrc file to set your color scheme.

When running the gogh.sh script as root, theme files are put into /usr/local/share/vtrgb-gogh and under Debian based systems the installed themes are installed as alternatives to the default colors in /etc/vtrgb and can be set as the default system theme using

> sudo update-alternatives --config vtrgb
