### PR TITLE
Feat: apply_kitty(): reload config after applying theme

### DIFF
--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -578,8 +578,9 @@ apply_kitty() {
   [ -n "$HIGHLIGHT_BG_COLOR" ] && echo "selection_background $HIGHLIGHT_BG_COLOR" >> "$CFGFILE"
 
   echo "cursor $CURSOR_COLOR" >> "$CFGFILE"
-
-  echo "Done - please reopen your kitty terminal to see the changes"
+  
+  echo "Done - signaling kitty to reload"
+  killall -u ${USER} -SIGUSR1 kitty || pkill --uid $(id -u) -SIGUSR1 kitty || echo "Reload failed. Please reopen your kitty terminal to see the changes."
 }
 
 apply_konsole() {


### PR DESCRIPTION
From the man page:

> You can reload the config file within kitty by pressing ctrl+shift+f5 (⌃+⌘+, on macOS) or sending kitty the SIGUSR1 signal.

This patch sends kitty a signal to hot-reload the config after it's done. Because I recall some weird systems not including one of either `killall` or `pkill` in the past let's just try them both. (The `||` operator is short for "if the command to the left fails (exit code >= 1), run the command on the right." So first we try `killall`, and then we try `pkill`. We also ask both commands to filter by the current user, so as to not attempt to ask another user's kitty process to reload (and so as not to cause an error because we tried).

It should be noted that doing this on macOS an old version of Kitty from before August 2021 will actually kill kitty. I'm not sure if it would be better to not do this on macOS in case someone running your script has an old version of Kitty, but I'd think it's probably safe? I'm not sure if kitty auto-updates.

Whether or not you want to include this change, it might not be a bad idea to at least update the "done" message to mention the additional ways one can reload the config.