### PR TITLE
add and fix selenized themes

### DIFF
--- a/themes/Selenized Black.yml
+++ b/themes/Selenized Black.yml
@@ -1,0 +1,25 @@
+---
+name: 'Selenized Black'
+
+color_01: '#252525'    # Black (Host) 
+color_02: '#ed4a46'    # Red (Syntax string)
+color_03: '#70b433'    # Green (Command)
+color_04: '#dbb32d'    # Yellow (Command second)
+color_05: '#368aeb'    # Blue (Path)
+color_06: '#eb6eb7'    # Magenta (Syntax var)
+color_07: '#3fc5b7'    # Cyan (Prompt)
+color_08: '#777777'    # White
+
+color_09: '#3b3b3b'    # Bright Black
+color_10: '#ff5e56'    # Bright Red (Command error)
+color_11: '#83c746'    # Bright Green (Exec)
+color_12: '#efc541'    # Bright Yellow
+color_13: '#4f9cfe'    # Bright Blue (Folder)
+color_14: '#ff81ca'    # Bright Magenta
+color_15: '#56d8c9'    # Bright Cyan
+color_16: '#dedede'    # Bright White
+
+background: '#181818'  # Background
+foreground: '#b9b9b9'  # Foreground (Text)
+
+cursor: '#dedede'      # Cursor

--- a/themes/Selenized Dark.yml
+++ b/themes/Selenized Dark.yml
@@ -1,16 +1,16 @@
 ---
 name: 'Selenized Dark'
 
-color_01: '#103c48'    # Black (Host)
+color_01: '#184956'    # Black (Host) 
 color_02: '#fa5750'    # Red (Syntax string)
 color_03: '#75b938'    # Green (Command)
 color_04: '#dbb32d'    # Yellow (Command second)
 color_05: '#4695f7'    # Blue (Path)
 color_06: '#f275be'    # Magenta (Syntax var)
 color_07: '#41c7b9'    # Cyan (Prompt)
-color_08: '#adbcbc'    # White
+color_08: '#72898f'    # White
 
-color_09: '#184956'    # Bright Black
+color_09: '#2d5b69'    # Bright Black
 color_10: '#ff665c'    # Bright Red (Command error)
 color_11: '#84c747'    # Bright Green (Exec)
 color_12: '#ebc13d'    # Bright Yellow
@@ -22,4 +22,4 @@ color_16: '#cad8d9'    # Bright White
 background: '#103c48'  # Background
 foreground: '#adbcbc'  # Foreground (Text)
 
-cursor: '#adbcbc'      # Cursor
+cursor: '#cad8d9'      # Cursor

--- a/themes/Selenized Light.yml
+++ b/themes/Selenized Light.yml
@@ -1,16 +1,16 @@
 ---
 name: 'Selenized Light'
 
-color_01: '#fbf3db'    # Black (Host)
+color_01: '#ece3cc'    # Black (Host) 
 color_02: '#d2212d'    # Red (Syntax string)
 color_03: '#489100'    # Green (Command)
 color_04: '#ad8900'    # Yellow (Command second)
 color_05: '#0072d4'    # Blue (Path)
 color_06: '#ca4898'    # Magenta (Syntax var)
 color_07: '#009c8f'    # Cyan (Prompt)
-color_08: '#53676d'    # White
+color_08: '#909995'    # White
 
-color_09: '#ece3cc'    # Bright Black
+color_09: '#d5cdb6'    # Bright Black
 color_10: '#cc1729'    # Bright Red (Command error)
 color_11: '#428b00'    # Bright Green (Exec)
 color_12: '#a78300'    # Bright Yellow
@@ -22,4 +22,4 @@ color_16: '#3a4d53'    # Bright White
 background: '#fbf3db'  # Background
 foreground: '#53676d'  # Foreground (Text)
 
-cursor: '#53676d'      # Cursor
+cursor: '#3a4d53'      # Cursor

--- a/themes/Selenized White.yml
+++ b/themes/Selenized White.yml
@@ -1,0 +1,25 @@
+---
+name: 'Selenized White'
+
+color_01: '#ebebeb'    # Black (Host) 
+color_02: '#d6000c'    # Red (Syntax string)
+color_03: '#1d9700'    # Green (Command)
+color_04: '#c49700'    # Yellow (Command second)
+color_05: '#0064e4'    # Blue (Path)
+color_06: '#dd0f9d'    # Magenta (Syntax var)
+color_07: '#00ad9c'    # Cyan (Prompt)
+color_08: '#878787'    # White
+
+color_09: '#cdcdcd'    # Bright Black
+color_10: '#bf0000'    # Bright Red (Command error)
+color_11: '#008400'    # Bright Green (Exec)
+color_12: '#af8500'    # Bright Yellow
+color_13: '#0054cf'    # Bright Blue (Folder)
+color_14: '#c7008b'    # Bright Magenta
+color_15: '#009a8a'    # Bright Cyan
+color_16: '#282828'    # Bright White
+
+background: '#ffffff'  # Background
+foreground: '#474747'  # Foreground (Text)
+
+cursor: '#282828'      # Cursor


### PR DESCRIPTION
Add and fix four Selenized themes according official values for sRGB:
- [Color mapping](https://github.com/jan-warchol/selenized/blob/master/manual-installation.md)
- [Color coordinates](https://github.com/jan-warchol/selenized/blob/master/the-values.md)

```
Selenized mapping
==================

color_01: # Black (Host) - [bg_1]
color_02: # Red (Syntax string) - [red]
color_03: # Green (Command) - [green]
color_04: # Yellow (Command second) - [yellow]
color_05: # Blue (Path) - [blue]
color_06: # Magenta (Syntax var) - [magenta]
color_07: # Cyan (Prompt) - [cyan]
color_08: # White - [dim_0]

color_09: # Bright Black - [bg_2]
color_10: # Bright Red (Command error) - [br_red]
color_11: # Bright Green (Exec) - [br_green]
color_12: # Bright Yellow - [br_yellow]
color_13: # Bright Blue (Folder) - [br_blue]
color_14: # Bright Magenta - [br_magenta]
color_15: # Bright Cyan - [br_cyan]
color_16: # Bright White - [fg_1]

background: # Background - [bg_0]
foreground: # Foreground (Text) - [fg_0]

cursor: # Cursor - [fg_1]
```