### PR TITLE
Improve Non-interactive use of script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ gh-pages/node_modules
 .stfolder
 apply-colors-original.sh
 .tmp
+venv
+.venv
+.*.swp

--- a/README.md
+++ b/README.md
@@ -96,9 +96,13 @@ bash -c "$(curl -sLo- https://git.io/vQgMr)"
 <br/>
 
 ## ⚙️ Install (non-interactive mode)
+Two ways:
+* Clone repo
+* Download only required files (bare minimum)
 
+### Clone repo
 ```bash
-# clone the repo into "$HOME/src/gogh"
+# Clone the repo into "$HOME/src/gogh"
 mkdir -p "$HOME/src"
 cd "$HOME/src"
 git clone https://github.com/Gogh-Co/Gogh.git gogh
@@ -117,6 +121,31 @@ cd installs
 # install themes
 ./atom.sh
 ./dracula.sh
+```
+
+### Download only required files (bare minimum)
+```bash
+# Download apply script
+wget https://github.com/Gogh-Co/Gogh/raw/master/apply-colors.sh
+# Download desired themes from Gogh/installs dir like this one:
+wget https://github.com/Gogh-Co/Gogh/raw/master/installs/selenized-dark.sh
+
+# Optional - download Alacritty dependency (may require additional python packages, see requirements.txt for more)
+wget https://github.com/Gogh-Co/Gogh/raw/master/apply-alacritty.py
+# Optional - download Terminator dependency (may require additional python packages, see requirements.txt for more)
+wget https://github.com/Gogh-Co/Gogh/raw/master/apply-terminator.py
+
+# Note you can also tell the theme file where to find the the apply scripts with the following environmental variables:
+# - GOGH_APPLY_SCRIPT=/path/to/file/apply-colors.sh
+# - GOGH_ALACRITTY_SCRIPT=/path/to/file/apply-alacritty.py  <-- only needed if applying to Alacritty terminal
+# - GOGH_TERMINATOR_SCRIPT=/path/to/file/apply-terminator.py  <-- only needed if applying to Terminator terminal
+
+# Select for which terminal to install the theme (see apply-colors.sh for all supported terminals)
+export TERMINAL=gnome-terminal
+# Apply downloaded theme (apply script must be in the same folder)
+bash ./selenized-dark.sh
+# OR specify apply script path
+GOGH_APPLY_SCRIPT=/path/to/file/apply-colors.sh bash ./selenized-dark.sh
 ```
 
 <br/>

--- a/installs/3024-day.sh
+++ b/installs/3024-day.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#4A4543" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/3024-night.sh
+++ b/installs/3024-night.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A5A2A2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/aci.sh
+++ b/installs/aci.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B4E1FD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/aco.sh
+++ b/installs/aco.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B4E1FD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/adventure-time.sh
+++ b/installs/adventure-time.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F8DCC0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/afterglow.sh
+++ b/installs/afterglow.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D0D0D0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/alien-blood.sh
+++ b/installs/alien-blood.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#637D75" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/apprentice.sh
+++ b/installs/apprentice.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BCBCBC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/argonaut.sh
+++ b/installs/argonaut.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFAF4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/arthur.sh
+++ b/installs/arthur.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DDEEDD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/atom.sh
+++ b/installs/atom.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C5C8C6" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/aura.sh
+++ b/installs/aura.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#EDECEE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ayu-dark.sh
+++ b/installs/ayu-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E6B450" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ayu-light.sh
+++ b/installs/ayu-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FF9940" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ayu-mirage.sh
+++ b/installs/ayu-mirage.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFCC66" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/azu.sh
+++ b/installs/azu.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9E6F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/belafonte-day.sh
+++ b/installs/belafonte-day.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#45373C" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/belafonte-night.sh
+++ b/installs/belafonte-night.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#968C83" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/bim.sh
+++ b/installs/bim.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A9BED8" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/birds-of-paradise.sh
+++ b/installs/birds-of-paradise.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E0DBB7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/blazer.sh
+++ b/installs/blazer.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9E6F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/blue-dolphin.sh
+++ b/installs/blue-dolphin.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFCC00" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/bluloco-light.sh
+++ b/installs/bluloco-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#383A42" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/bluloco-zsh-light.sh
+++ b/installs/bluloco-zsh-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#383A42" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/borland.sh
+++ b/installs/borland.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFF4E" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/breath-darker.sh
+++ b/installs/breath-darker.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#17A88B" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/breath-light.sh
+++ b/installs/breath-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#292F34" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/breath-silverfox.sh
+++ b/installs/breath-silverfox.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BBBBBB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/breath.sh
+++ b/installs/breath.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#17A88B" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/breeze.sh
+++ b/installs/breeze.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FCFCFC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/broadcast.sh
+++ b/installs/broadcast.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E6E1DC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/brogrammer.sh
+++ b/installs/brogrammer.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D6DBE5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/butrin.sh
+++ b/installs/butrin.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E39D93" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/c64.sh
+++ b/installs/c64.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#7869C4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/cai.sh
+++ b/installs/cai.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9E6F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/campbell.sh
+++ b/installs/campbell.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/catppuccin-frappe.sh
+++ b/installs/catppuccin-frappe.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C6D0F5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/catppuccin-latte.sh
+++ b/installs/catppuccin-latte.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#4C4F69" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/catppuccin-macchiato.sh
+++ b/installs/catppuccin-macchiato.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CAD3F5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/catppuccin-mocha.sh
+++ b/installs/catppuccin-mocha.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CDD6F4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/chalk.sh
+++ b/installs/chalk.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D4D4D4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/chalkboard.sh
+++ b/installs/chalkboard.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9E6F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/chameleon.sh
+++ b/installs/chameleon.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DEDEDE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ciapre.sh
+++ b/installs/ciapre.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#AEA47A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/clone-of-ubuntu.sh
+++ b/installs/clone-of-ubuntu.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/clrs.sh
+++ b/installs/clrs.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#262626" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/cobalt-2.sh
+++ b/installs/cobalt-2.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/cobalt-neon.sh
+++ b/installs/cobalt-neon.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#8FF586" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/colorcli.sh
+++ b/installs/colorcli.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#005F87" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/crayon-pony-fish.sh
+++ b/installs/crayon-pony-fish.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#68525A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/dark-pastel.sh
+++ b/installs/dark-pastel.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/darkside.sh
+++ b/installs/darkside.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BABABA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/dehydration.sh
+++ b/installs/dehydration.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CCCCCC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/desert.sh
+++ b/installs/desert.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/dimmed-monokai.sh
+++ b/installs/dimmed-monokai.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B9BCBA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/dissonance.sh
+++ b/installs/dissonance.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DC322F" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/dracula.sh
+++ b/installs/dracula.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#f8f8f2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/earthsong.sh
+++ b/installs/earthsong.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E5C7A9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/elemental.sh
+++ b/installs/elemental.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#807A74" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/elementary.sh
+++ b/installs/elementary.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F2F2F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/elic.sh
+++ b/installs/elic.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F2F2F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/elio.sh
+++ b/installs/elio.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F2F2F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/espresso-libre.sh
+++ b/installs/espresso-libre.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B8A898" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/espresso.sh
+++ b/installs/espresso.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everblush.sh
+++ b/installs/everblush.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DADADA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everforest-dark-hard.sh
+++ b/installs/everforest-dark-hard.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D3C6AA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everforest-dark-medium.sh
+++ b/installs/everforest-dark-medium.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D3C6AA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everforest-dark-soft.sh
+++ b/installs/everforest-dark-soft.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D3C6AA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everforest-light-hard.sh
+++ b/installs/everforest-light-hard.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#5C6A72" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everforest-light-medium.sh
+++ b/installs/everforest-light-medium.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#5C6A72" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/everforest-light-soft.sh
+++ b/installs/everforest-light-soft.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#5C6A72" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/fairy-floss-dark.sh
+++ b/installs/fairy-floss-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFB8D1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/fairy-floss.sh
+++ b/installs/fairy-floss.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFB8D1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/fishtank.sh
+++ b/installs/fishtank.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ECF0FE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/flat-remix.sh
+++ b/installs/flat-remix.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/flat.sh
+++ b/installs/flat.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#1ABC9C" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/flatland.sh
+++ b/installs/flatland.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B8DBEF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/foxnightly.sh
+++ b/installs/foxnightly.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D7D7DB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/freya.sh
+++ b/installs/freya.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#839496" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/frontend-delight.sh
+++ b/installs/frontend-delight.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ADADAD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/frontend-fun-forrest.sh
+++ b/installs/frontend-fun-forrest.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DEC165" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/frontend-galaxy.sh
+++ b/installs/frontend-galaxy.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/geohot.sh
+++ b/installs/geohot.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/github-dark.sh
+++ b/installs/github-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C9D1D9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/github-light.sh
+++ b/installs/github-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#1f2328" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/gogh.sh
+++ b/installs/gogh.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BFC7D5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/gooey.sh
+++ b/installs/gooey.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#EBEEF9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/google-dark.sh
+++ b/installs/google-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E8EAED" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/google-light.sh
+++ b/installs/google-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#5F6368" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/gotham.sh
+++ b/installs/gotham.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#98D1CE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/grape.sh
+++ b/installs/grape.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#9F9FA1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/grass.sh
+++ b/installs/grass.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFF0A5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/gruvbox-dark.sh
+++ b/installs/gruvbox-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#EBDBB2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/gruvbox-material.sh
+++ b/installs/gruvbox-material.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D4BE98" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/gruvbox.sh
+++ b/installs/gruvbox.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#3C3836" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/hardcore.sh
+++ b/installs/hardcore.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A0A0A0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/harper.sh
+++ b/installs/harper.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A8A49D" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/hemisu-dark.sh
+++ b/installs/hemisu-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BAFFAA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/hemisu-light.sh
+++ b/installs/hemisu-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FF0054" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/highway.sh
+++ b/installs/highway.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#EDEDED" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/hipster-green.sh
+++ b/installs/hipster-green.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#84C138" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/homebrew-light.sh
+++ b/installs/homebrew-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#000000" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/homebrew-ocean.sh
+++ b/installs/homebrew-ocean.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/homebrew.sh
+++ b/installs/homebrew.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#00FF00" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/horizon-bright.sh
+++ b/installs/horizon-bright.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#1C1E26" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/horizon-dark.sh
+++ b/installs/horizon-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FDF0ED" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/hurtado.sh
+++ b/installs/hurtado.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DBDBDB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/hybrid.sh
+++ b/installs/hybrid.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#94A3A5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ibm-3270-high-contrast.sh
+++ b/installs/ibm-3270-high-contrast.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FDFDFD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ibm3270.sh
+++ b/installs/ibm3270.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FDFDFD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ic-green-ppl.sh
+++ b/installs/ic-green-ppl.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9EFD3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ic-orange-ppl.sh
+++ b/installs/ic-orange-ppl.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFCB83" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/iceberg.sh
+++ b/installs/iceberg.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#d2d4de" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/idle-toes.sh
+++ b/installs/idle-toes.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ir-black.sh
+++ b/installs/ir-black.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFA560" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/jackie-brown.sh
+++ b/installs/jackie-brown.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFCC2F" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/japanesque.sh
+++ b/installs/japanesque.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F7F6EC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/jellybeans.sh
+++ b/installs/jellybeans.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DEDEDE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/jup.sh
+++ b/installs/jup.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#23476A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/kanagawa-dragon.sh
+++ b/installs/kanagawa-dragon.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C8C093" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/kanagawa.sh
+++ b/installs/kanagawa.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DCD7BA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/kibble.sh
+++ b/installs/kibble.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F7F7F7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/kokuban.sh
+++ b/installs/kokuban.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D8E2D7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/laserwave.sh
+++ b/installs/laserwave.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C7C7C7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/later-this-evening.sh
+++ b/installs/later-this-evening.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#959595" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/lavandula.sh
+++ b/installs/lavandula.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#736E7D" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/liquid-carbon-transparent.sh
+++ b/installs/liquid-carbon-transparent.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#AFC2C2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/liquid-carbon.sh
+++ b/installs/liquid-carbon.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#AFC2C2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/lunaria-dark.sh
+++ b/installs/lunaria-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CACED8" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/lunaria-eclipse.sh
+++ b/installs/lunaria-eclipse.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C9CDD7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/lunaria-light.sh
+++ b/installs/lunaria-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#484646" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/maia.sh
+++ b/installs/maia.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BDC3C7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/man-page.sh
+++ b/installs/man-page.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#000000" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mar.sh
+++ b/installs/mar.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#23476A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/material.sh
+++ b/installs/material.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#657B83" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mathias.sh
+++ b/installs/mathias.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BBBBBB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/medallion.sh
+++ b/installs/medallion.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CAC296" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/miramare.sh
+++ b/installs/miramare.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#e6d6ac" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/misterioso.sh
+++ b/installs/misterioso.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E1E1E0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/modus-operandi-tinted.sh
+++ b/installs/modus-operandi-tinted.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#000000" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/modus-operandi.sh
+++ b/installs/modus-operandi.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#000000" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/modus-vivendi-tinted.sh
+++ b/installs/modus-vivendi-tinted.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ffffff" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/modus-vivendi.sh
+++ b/installs/modus-vivendi.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ffffff" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/molokai.sh
+++ b/installs/molokai.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BBBBBB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mona-lisa.sh
+++ b/installs/mona-lisa.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F7D66A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mono-amber.sh
+++ b/installs/mono-amber.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FF9400" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mono-cyan.sh
+++ b/installs/mono-cyan.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#00CCFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mono-green.sh
+++ b/installs/mono-green.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#0BFF00" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mono-red.sh
+++ b/installs/mono-red.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FF3600" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mono-white.sh
+++ b/installs/mono-white.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FAFAFA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/mono-yellow.sh
+++ b/installs/mono-yellow.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFD300" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/monokai-dark.sh
+++ b/installs/monokai-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F8F8F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/monokai-pro-ristretto.sh
+++ b/installs/monokai-pro-ristretto.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FBF2F3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/monokai-pro.sh
+++ b/installs/monokai-pro.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FDF9F3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/monokai-soda.sh
+++ b/installs/monokai-soda.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C4C5B5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/moonfly.sh
+++ b/installs/moonfly.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#9E9E9E" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/morada.sh
+++ b/installs/morada.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/n0tch2k.sh
+++ b/installs/n0tch2k.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A0A0A0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/neon-night.sh
+++ b/installs/neon-night.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C7C8FF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/neopolitan.sh
+++ b/installs/neopolitan.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nep.sh
+++ b/installs/nep.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#23476A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/neutron.sh
+++ b/installs/neutron.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E6E8EF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/night-owl.sh
+++ b/installs/night-owl.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D6DEEB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nightfly.sh
+++ b/installs/nightfly.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#9CA1AA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nightlion-v1.sh
+++ b/installs/nightlion-v1.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BBBBBB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nightlion-v2.sh
+++ b/installs/nightlion-v2.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BBBBBB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nighty.sh
+++ b/installs/nighty.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DFDFDF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nord-light.sh
+++ b/installs/nord-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#439ECF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/nord.sh
+++ b/installs/nord.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D8DEE9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/novel.sh
+++ b/installs/novel.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#3B2322" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/obsidian.sh
+++ b/installs/obsidian.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CDCDCD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ocean-dark.sh
+++ b/installs/ocean-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#979CAC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/oceanic-next.sh
+++ b/installs/oceanic-next.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B3B8C3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ollie.sh
+++ b/installs/ollie.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#8A8DAE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/omni.sh
+++ b/installs/omni.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ABB2BF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/one-dark.sh
+++ b/installs/one-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#5C6370" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/one-half-black.sh
+++ b/installs/one-half-black.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DCDFE4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/one-light.sh
+++ b/installs/one-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#2A2B32" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/oxocarbon-dark.sh
+++ b/installs/oxocarbon-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#6F6F6F" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/palenight.sh
+++ b/installs/palenight.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BFC7D5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/pali.sh
+++ b/installs/pali.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9E6F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/panda.sh
+++ b/installs/panda.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F0F0F0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/paper.sh
+++ b/installs/paper.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#000000" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/papercolor-dark.sh
+++ b/installs/papercolor-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D0D0D0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/papercolor-light.sh
+++ b/installs/papercolor-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#444444" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/paraiso-dark.sh
+++ b/installs/paraiso-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A39E9B" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/paul-millr.sh
+++ b/installs/paul-millr.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F2F2F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/pencil-dark.sh
+++ b/installs/pencil-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F1F1F1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/pencil-light.sh
+++ b/installs/pencil-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#424242" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/peppermint.sh
+++ b/installs/peppermint.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BBBBBB" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/pixiefloss.sh
+++ b/installs/pixiefloss.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D1CAE8" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/pnevma.sh
+++ b/installs/pnevma.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D0D0D0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/powershell.sh
+++ b/installs/powershell.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F6F6F7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/predawn.sh
+++ b/installs/predawn.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F1F1F1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/pro.sh
+++ b/installs/pro.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F2F2F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/purple-people-eater.sh
+++ b/installs/purple-people-eater.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C9D1D9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/quiet.sh
+++ b/installs/quiet.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A0A0A0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/red-alert.sh
+++ b/installs/red-alert.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/red-sands.sh
+++ b/installs/red-sands.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D7C9A7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/relaxed.sh
+++ b/installs/relaxed.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9D9D9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/rippedcasts.sh
+++ b/installs/rippedcasts.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/rose-pine-dawn.sh
+++ b/installs/rose-pine-dawn.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#575279" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/rose-pine-moon.sh
+++ b/installs/rose-pine-moon.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E0DEF4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/rose-pine.sh
+++ b/installs/rose-pine.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E0DEF4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/royal.sh
+++ b/installs/royal.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#514968" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sat.sh
+++ b/installs/sat.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#23476A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sea-shells.sh
+++ b/installs/sea-shells.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DEB88D" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/seafoam-pastel.sh
+++ b/installs/seafoam-pastel.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D4E7D4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/selenized-black.sh
+++ b/installs/selenized-black.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#dedede" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/selenized-dark.sh
+++ b/installs/selenized-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#cad8d9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/selenized-light.sh
+++ b/installs/selenized-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#3a4d53" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/selenized-white.sh
+++ b/installs/selenized-white.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#282828" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/seoul256-light.sh
+++ b/installs/seoul256-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#4e4e4e" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/seoul256.sh
+++ b/installs/seoul256.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#d0d0d0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/seti.sh
+++ b/installs/seti.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CACECD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/shaman.sh
+++ b/installs/shaman.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#405555" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/shel.sh
+++ b/installs/shel.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#4882CD" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/slate.sh
+++ b/installs/slate.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#35B1D2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/smyck.sh
+++ b/installs/smyck.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F7F7F7" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/snazzy.sh
+++ b/installs/snazzy.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#97979B" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/soft-server.sh
+++ b/installs/soft-server.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#99A3A2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/solarized-darcula.sh
+++ b/installs/solarized-darcula.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D2D8D9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/solarized-dark-higher-contrast.sh
+++ b/installs/solarized-dark-higher-contrast.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#9CC2C3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/solarized-dark.sh
+++ b/installs/solarized-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#839496" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/solarized-light.sh
+++ b/installs/solarized-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#657B83" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sonokai.sh
+++ b/installs/sonokai.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E2E2E3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/spacedust.sh
+++ b/installs/spacedust.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ECF0C1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/spacegray-eighties-dull.sh
+++ b/installs/spacegray-eighties-dull.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C9C6BC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/spacegray-eighties.sh
+++ b/installs/spacegray-eighties.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#BDBAAE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/spacegray.sh
+++ b/installs/spacegray.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B3B8C3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sparky.sh
+++ b/installs/sparky.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F4F5F0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/spring.sh
+++ b/installs/spring.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#ECF0C1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/square.sh
+++ b/installs/square.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#A1A1A1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/srcery.sh
+++ b/installs/srcery.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FBB829" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/summer-pop.sh
+++ b/installs/summer-pop.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sundried.sh
+++ b/installs/sundried.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C9C9C9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sweet-eliverlara.sh
+++ b/installs/sweet-eliverlara.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C3C7D1" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/sweet-terminal.sh
+++ b/installs/sweet-terminal.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/symphonic.sh
+++ b/installs/symphonic.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/synthwave-alpha.sh
+++ b/installs/synthwave-alpha.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F2F2E3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/synthwave.sh
+++ b/installs/synthwave.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#03EDF9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/teerb.sh
+++ b/installs/teerb.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D0D0D0" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tender.sh
+++ b/installs/tender.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#EEEEEE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/terminal-basic.sh
+++ b/installs/terminal-basic.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#7f7f7f" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/terminix-dark.sh
+++ b/installs/terminix-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#868A8C" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/thayer-bright.sh
+++ b/installs/thayer-bright.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#F8F8F8" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tin.sh
+++ b/installs/tin.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tokyo-night-light.sh
+++ b/installs/tokyo-night-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#565A6E" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tokyo-night-storm.sh
+++ b/installs/tokyo-night-storm.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C0CAF5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tokyo-night.sh
+++ b/installs/tokyo-night.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C0CAF5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tomorrow-night-blue.sh
+++ b/installs/tomorrow-night-blue.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFEFE" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tomorrow-night-bright.sh
+++ b/installs/tomorrow-night-bright.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#E9E9E9" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tomorrow-night-eighties.sh
+++ b/installs/tomorrow-night-eighties.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CCCCCC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tomorrow-night.sh
+++ b/installs/tomorrow-night.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#C4C8C5" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/tomorrow.sh
+++ b/installs/tomorrow.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#4C4C4C" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/toy-chest.sh
+++ b/installs/toy-chest.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#31D07B" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/treehouse.sh
+++ b/installs/treehouse.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#786B53" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/twilight.sh
+++ b/installs/twilight.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFD4" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/ura.sh
+++ b/installs/ura.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#23476A" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/urple.sh
+++ b/installs/urple.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#877A9B" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/vag.sh
+++ b/installs/vag.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#D9E6F2" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/vaughn.sh
+++ b/installs/vaughn.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DCDCCC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/vibrant-ink.sh
+++ b/installs/vibrant-ink.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FFFFFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/vs-code-dark.sh
+++ b/installs/vs-code-dark.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#CCCCCC" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/vs-code-light.sh
+++ b/installs/vs-code-light.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#020202" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/warm-neon.sh
+++ b/installs/warm-neon.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#AFDAB6" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/website.sh
+++ b/installs/website.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#d1b890" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/wez.sh
+++ b/installs/wez.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#B3B3B3" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/wild-cherry.sh
+++ b/installs/wild-cherry.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DAFAFF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/wombat.sh
+++ b/installs/wombat.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#DEDACF" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/wryan.sh
+++ b/installs/wryan.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#999993" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/wzoreck.sh
+++ b/installs/wzoreck.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#FCFCFA" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/installs/zenburn.sh
+++ b/installs/zenburn.sh
@@ -31,19 +31,13 @@ export CURSOR_COLOR="#dcdccc" # Cursor
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}
-
-
-if [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+  bash "${GOGH_APPLY_SCRIPT}"
+elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
   bash "${PARENT_PATH}/apply-colors.sh"
+elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+  bash "${SCRIPT_PATH}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${BASE_URL}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${BASE_URL}/apply-colors.sh")"
-  fi
+  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ unidecode
 pyyaml
 tomli
 tomli_w
+configobj

--- a/tools/generateShFiles.py
+++ b/tools/generateShFiles.py
@@ -71,21 +71,15 @@ export CURSOR_COLOR="{cursorColor}" # Cursor
 SCRIPT_PATH="${{SCRIPT_PATH:-$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)}}"
 PARENT_PATH="$(dirname "${{SCRIPT_PATH}}")"
 
-# Allow developer to change url to forked url for easier testing
-# IMPORTANT: Make sure you export this variable if your main shell is not bash
-BASE_URL=${{BASE_URL:-"https://raw.githubusercontent.com/Gogh-Co/Gogh/master"}}
-
-
-if [[ -e "${{PARENT_PATH}}/apply-colors.sh" ]]; then
+if [[ -e "${{GOGH_APPLY_SCRIPT}}" ]]; then
+  bash "${{GOGH_APPLY_SCRIPT}}"
+elif [[ -e "${{PARENT_PATH}}/apply-colors.sh" ]]; then
   bash "${{PARENT_PATH}}/apply-colors.sh"
+elif [[ -e "${{SCRIPT_PATH}}/apply-colors.sh" ]]; then
+  bash "${{SCRIPT_PATH}}/apply-colors.sh"
 else
-  if [[ "$(uname)" = "Darwin" ]]; then
-    # OSX ships with curl and ancient bash
-    bash -c "$(curl -so- "${{BASE_URL}}/apply-colors.sh")"
-  else
-    # Linux ships with wget
-    bash -c "$(wget -qO- "${{BASE_URL}}/apply-colors.sh")"
-  fi
+  printf '\\n%s\\n' "Error: Couldn't find apply-colors.sh"
+  exit 1
 fi
 """
 


### PR DESCRIPTION
This commit improves Gogh security and usage when being used non-interactively (for usage with scripts)

It includes not only one but multiple improvements:
* Close potential backdoor by removing downloading of files from remote servers
  * Instead files must be downloaded manually beforehand when using theme shell scripts directly
  * `gogh.sh` is unaffected, it will download the files
* Remove hardcoded path for apply scripts in theme shell scripts (was parent dir)
  * Instead the path to the apply scripts can be set by following environmental variables
    * `GOGH_APPLY_SCRIPT`
    * `GOGH_TERMINATOR_SCRIPT`
    * `GOGH_ALACRITTY_SCRIPT`
  * Fallback to old behavior if no path was given
* Add missing Python requirement for Terminator script
* Add additional .gitignore files to cover Vim swap files and Python virtual environment

I could split up the commit into 3 smaller ones, but the GOGH_* environment feature and removal of file downloading is closely coupled and therefore cannot be split up into smaller commits.