### PR TITLE
Add GOGH_NONINTERACTIVE flag for non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cd installs
 ```bash
 # Download apply script
 wget https://github.com/Gogh-Co/Gogh/raw/master/apply-colors.sh
-# Download desired themes from Gogh/installs dir like this one:
+# Download desired themes from ./installs/ like this:
 wget https://github.com/Gogh-Co/Gogh/raw/master/installs/selenized-dark.sh
 
 # Optional - download Alacritty dependency (may require additional python packages, see requirements.txt for more)
@@ -135,15 +135,19 @@ wget https://github.com/Gogh-Co/Gogh/raw/master/apply-alacritty.py
 # Optional - download Terminator dependency (may require additional python packages, see requirements.txt for more)
 wget https://github.com/Gogh-Co/Gogh/raw/master/apply-terminator.py
 
-# Note you can also tell the theme file where to find the the apply scripts with the following environmental variables:
-# - GOGH_APPLY_SCRIPT=/path/to/file/apply-colors.sh
-# - GOGH_ALACRITTY_SCRIPT=/path/to/file/apply-alacritty.py  <-- only needed if applying to Alacritty terminal
-# - GOGH_TERMINATOR_SCRIPT=/path/to/file/apply-terminator.py  <-- only needed if applying to Terminator terminal
+# You can also specify where to find the apply scripts with the following environmental variables
+GOGH_APPLY_SCRIPT=/path/to/apply-colors.sh
+GOGH_ALACRITTY_SCRIPT=/path/to/apply-alacritty.py   # only needed if applying to Alacritty terminal
+GOGH_TERMINATOR_SCRIPT=/path/to/apply-terminator.py # only needed if applying to Terminator terminal
 
-# Select for which terminal to install the theme (see apply-colors.sh for all supported terminals)
-export TERMINAL=gnome-terminal
+# Control Gogh behavior with the following environmental variables
+TERMINAL=gnome-terminal # Select for which terminal to install the theme
+                        # (see apply-colors.sh for all supported terminals)
+GOGH_NONINTERACTIVE= # Make output silent and answer all prompts with default value
+                     # (errors will still be printed)
+
 # Apply downloaded theme (apply script must be in the same folder)
-bash ./selenized-dark.sh
+TERMINAL=gnome-terminal bash ./selenized-dark.sh
 # OR specify apply script path
 GOGH_APPLY_SCRIPT=/path/to/file/apply-colors.sh bash ./selenized-dark.sh
 ```

--- a/apply-alacritty.py
+++ b/apply-alacritty.py
@@ -8,6 +8,10 @@ import tomli_w
 from ruamel.yaml import YAML  # use ruamel.yaml to preserve comments in config
 
 
+def printerr(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
 def get_conf_path():
     # Determine system
     # When we are in some Java world do extra checks
@@ -58,7 +62,7 @@ def get_conf_path():
         if home is not None and os.path.exists(home + '/.alacritty.toml'):
             return home + "/.alacritty.toml"
 
-    print("Could not find alacritty config file\nPlease make sure you have a file in one of the paths specified on\nhttps://github.com/alacritty/alacritty#configuration")
+    printerr("Could not find alacritty config file\nPlease make sure you have a file in one of the paths specified on\nhttps://github.com/alacritty/alacritty#configuration")
     sys.exit(1)
 # end
 
@@ -74,6 +78,7 @@ elif conf_path.endswith('toml'):
     with open(conf_path, 'rb') as stream:
         data_loaded = tomli.load(stream)
 else:
+    printerr(f'Config parsing no available for config file {conf_path}')
     raise NotImplementedError(f'Config parsing not available for config file {conf_path}')
 
 # parse new colors
@@ -86,17 +91,18 @@ try:
     data_loaded['colors']['normal'].update(js['colors']['normal'])
     data_loaded['colors']['bright'].update(js['colors']['bright'])
 except KeyError:
-    print("Could not find existing 'colors' settings in your alacritty.yml file\nplease make sure to uncomment\n'colors', as well as 'primary', 'normal' and 'bright'")
-    print("Check the example config at\nhttps://github.com/alacritty/alacritty/releases/download/v0.12.2/alacritty.yml for more information")
-    print("Note that alacritty following release 0.13.0 uses toml configuration.")
+    printerr("Could not find existing 'colors' settings in your alacritty.yml file\nplease make sure to uncomment\n'colors', as well as 'primary', 'normal' and 'bright'")
+    printerr("Check the example config at\nhttps://github.com/alacritty/alacritty/releases/download/v0.12.2/alacritty.yml for more information")
+    printerr("Note that alacritty following release 0.13.0 uses toml configuration.")
     sys.exit(1)
 
 # make sure the user is okay with having their config changed
-answer = input("This script will update your alacritty config at: \n" +
-               conf_path + "\nIt is recommended to make a copy of this file before proceeding.\nAre you sure you want to continue? (Y/N)\n")
-if answer.lower() not in ['y', 'yes']:
-    print("Aborted")
-    sys.exit(1)
+if not "GOGH_NONINTERACTIVE" in os.environ:
+    answer = input("This script will update your alacritty config at: \n" +
+                   conf_path + "\nIt is recommended to make a copy of this file before proceeding.\nAre you sure you want to continue? (Y/N)\n")
+    if answer.lower() not in ['y', 'yes']:
+        print("Aborted")
+        sys.exit(1)
 
 # Write alacritty config
 if conf_path.endswith('yml'):

--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -46,6 +46,28 @@ PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 # will not get inherited. Hence traps defined in gogh.sh and print-themes.sh will still trigger
 trap 'GLOBAL_VAR_CLEANUP; trap - EXIT' EXIT HUP INT QUIT PIPE TERM
 
+print() {
+	format="${1:?missing value for print}"
+	shift
+	if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+		printf "${format}" "${@}"
+	fi
+}
+
+prints() {
+	print '%s\n' "${@}"
+}
+
+printerr() {
+	format="${1:?missing value for printerr}"
+	shift
+	printf "${format}" "${@}" 1>&2
+}
+
+printserr() {
+	printerr '%s\n' "${@}"
+}
+
 # |
 # | Second test for TERMINAL in case user ran
 # | theme script directly instead of gogh.sh
@@ -82,9 +104,9 @@ fi
 case "${TERMINAL}" in
   pantheon-terminal|io.elementary.t* )
     if [[ -z "${GS}" ]]; then
-      printf '\n%s\n' "Error gsettings not found"
-      printf '%s\n'   "sudo apt install dconf?"
-      printf '%s\n\n' "or export GS=/path/to/gsettings"
+      printerr '\n%s\n' "Error gsettings not found"
+      printerr '%s\n'   "sudo apt install dconf?"
+      printerr '%s\n\n' "or export GS=/path/to/gsettings"
       exit 1
     fi
     ;;
@@ -92,8 +114,8 @@ case "${TERMINAL}" in
   mintty )
     CFGFILE="${HOME}/.minttyrc"
     if [[ ! -f "${CFGFILE}" ]]; then
-      printf '\n%s\n' "Warning: Couldn't find an existing configuration file, so one will be created for you."
-      printf '%s\n\n' "Warning: Are you really running Cygwin's mintty?"
+      print '\n%s\n' "Warning: Couldn't find an existing configuration file, so one will be created for you."
+      print '%s\n\n' "Warning: Are you really running Cygwin's mintty?"
       touch "${CFGFILE}"
     fi
     ;;
@@ -102,17 +124,17 @@ case "${TERMINAL}" in
     case "${TERMINAL}" in
       guake|gnome-terminal* )
         if [[ -z "${DCONF}" ]] && [[ -z "${GCONF}" ]]; then
-          printf '\n%s\n' "Error gconftool not found!"
-          printf '%s\n'   "sudo apt install gconftool?"
-          printf '%s\n\n' "or export GCONF=/path/to/gconftool-2/"
+          printerr '\n%s\n' "Error gconftool not found!"
+          printerr '%s\n'   "sudo apt install gconftool?"
+          printerr '%s\n\n' "or export GCONF=/path/to/gconftool-2/"
           exit 1
         fi
         ;;
     esac
     if [[ -z "${DCONF}" ]]; then
-      printf '\n%s\n' "Error dconf not found"
-      printf '%s\n'   "sudo apt install dconf?"
-      printf '%s\n\n' "or export DCONF=/path/to/dconf"
+      printerr '\n%s\n' "Error dconf not found"
+      printerr '%s\n'   "sudo apt install dconf?"
+      printerr '%s\n\n' "or export DCONF=/path/to/dconf"
       exit 1
     fi
     ;;
@@ -120,7 +142,7 @@ case "${TERMINAL}" in
   foot )
     CFGFILE="${HOME}/.config/foot/foot.ini"
     if [[ ! -f "${CFGFILE}" ]]; then
-      printf '\n%s\n' "Error: Couldn't find an existing configuration file."
+      printerr '\n%s\n' "Error: Couldn't find an existing configuration file."
       exit 1
     fi
     ;;
@@ -131,7 +153,7 @@ case "${TERMINAL}" in
     fi
     CFGFILE="${KITTY_CONFIG_DIRECTORY}/kitty.conf"
     if [[ ! -f "${CFGFILE}" ]]; then
-      printf '\n%s\n' "Error: Couldn't find an existing configuration file for Kitty."
+      printerr '\n%s\n' "Error: Couldn't find an existing configuration file for Kitty."
       exit 1
     fi
     ;;
@@ -142,7 +164,7 @@ case "${TERMINAL}" in
       CFGFILE="${KMSCON_CONFIG_DIRECTORY}/kmscon.conf"
     fi
     if [[ ! -f "${CFGFILE}" ]]; then
-      printf '\n%s\n' "Error: Couldn't find an existing configuration file for KMSCon."
+      printerr '\n%s\n' "Error: Couldn't find an existing configuration file for KMSCon."
       exit 1
     fi
     ;;
@@ -151,7 +173,7 @@ case "${TERMINAL}" in
   konsole )
     CFGFILE="${HOME}/.config/konsolerc"
     if [[ ! -f "${CFGFILE}" ]]; then
-      printf '\n%s\n' "Error: Couldn't find an existing configuration file for Konsole."
+      printerr '\n%s\n' "Error: Couldn't find an existing configuration file for Konsole."
       exit 1
     fi
     ;;
@@ -390,7 +412,7 @@ if [[ "${COLORTERM:-}" == "truecolor" ]] || [[ "${COLORTERM:-}" == "24bit" ]]; t
       [[ ${GOGH_DRY_RUN:-0} -eq 1 ]] && export "DEMO_COLOR_$c=\033[38;2;${1};${2};${3}m"
       [[ "$c" == "08" ]] && color_str+="\n" # new line
     done
-    printf '\n%b\n\n\n' "${color_str}"
+    print '\n%b\n\n\n' "${color_str}"
     unset color_str
   }
 else
@@ -401,7 +423,7 @@ else
       color_str+="$(tput setaf $c)█████$(tput sgr0)"
       [[ $c == 7 ]] && color_str+="\n" # new line
     done
-    printf '\n%b\n\n' "${color_str}"
+    print '\n%b\n\n' "${color_str}"
     unset color_str
   }
 fi
@@ -445,7 +467,7 @@ apply_cygwin() {
   # | Applying values on mintty (cygwin)
   # | ===========================================
 
-  echo "Patching mintty configuration file (${CFGFILE}) with new colors..."
+  prints "Patching mintty configuration file (${CFGFILE}) with new colors..."
 
   updateMinttyConfig "$CFGFILE" "$COLOR_01"         "Black"
   updateMinttyConfig "$CFGFILE" "$COLOR_02"         "Red"
@@ -469,7 +491,7 @@ apply_cygwin() {
   updateMinttyConfig "$CFGFILE" "$FOREGROUND_COLOR" "Foregroundcolor"
   updateMinttyConfig "$CFGFILE" "$CURSOR_COLOR"     "Cursorcolor"
 
-  echo "Done - please reopen your Cygwin terminal to see the changes"
+  prints "Done - please reopen your Cygwin terminal to see the changes"
 }
 
 apply_alacritty() {
@@ -516,7 +538,7 @@ apply_alacritty() {
   elif [[ -e "${SCRIPT_PATH}/apply-alacritty.py" ]]; then
     python3 "${SCRIPT_PATH}/apply-alacritty.py" "$json_str"
   else
-    printf '\n%s\n' "Error: Couldn't find apply-alacritty.py file."
+    printerr '\n%s\n' "Error: Couldn't find apply-alacritty.py file."
     exit 1
   fi
 }
@@ -544,7 +566,7 @@ apply_terminator() {
   elif [[ -e "${SCRIPT_PATH}/apply-terminator.py" ]]; then
     python3 "${SCRIPT_PATH}/apply-terminator.py" "$json_str"
   else
-    printf '\n%s\n' "Error: Couldn't find apply-terminator.py."
+    printerr '\n%s\n' "Error: Couldn't find apply-terminator.py."
     exit 1
   fi
 
@@ -555,7 +577,7 @@ apply_foot() {
   # | Applying values on foot
   # | ===========================================
 
-  echo "Patching foot configuration file (${CFGFILE}) with new colors..."
+  prints "Patching foot configuration file (${CFGFILE}) with new colors..."
 
   updateFootConfig "$CFGFILE" "$COLOR_01" "regular0"
   updateFootConfig "$CFGFILE" "$COLOR_02" "regular1"
@@ -578,8 +600,7 @@ apply_foot() {
   updateFootConfig "$CFGFILE" "$BACKGROUND_COLOR" "background"
   updateFootConfig "$CFGFILE" "$FOREGROUND_COLOR" "foreground"
 
-  echo "Done - please reopen your foot terminal to see the changes"
-
+  prints "Done - please reopen your foot terminal to see the changes"
 }
 
 apply_kitty() {
@@ -587,7 +608,7 @@ apply_kitty() {
   # | Applying values on Kitty
   # | ===========================================
 
-  echo "Patching kitty configuration file ($CFGFILE) with include of color theme file..."
+  prints "Patching kitty configuration file ($CFGFILE) with include of color theme file..."
 
   COLOR_FILE="colors.conf"
 
@@ -599,7 +620,7 @@ apply_kitty() {
 
   CFGFILE="${KITTY_CONFIG_DIRECTORY}/$COLOR_FILE"
 
-  echo "Updating color theme file ($CFGFILE) with theme..."
+  pirnts "Updating color theme file ($CFGFILE) with theme..."
 
   rm -f "$CFGFILE"
 
@@ -631,15 +652,15 @@ apply_kitty() {
 
   echo "cursor $CURSOR_COLOR" >> "$CFGFILE"
   
-  echo "Done - signaling kitty to reload"
-  killall -u ${USER} -SIGUSR1 kitty || pkill --uid $(id -u) -SIGUSR1 kitty || echo "Reload failed. Please reopen your kitty terminal to see the changes."
+  prints "Done - signaling kitty to reload"
+  killall -u ${USER} -SIGUSR1 kitty || pkill --uid $(id -u) -SIGUSR1 kitty || prints "Reload failed. Please reopen your kitty terminal to see the changes."
 }
 
 apply_kmscon() {
   # |
   # | Applying values on kmscon | ===========================================
 
-  echo "Patching kmscon configuration file (${CFGFILE}) with new colors..."
+  prints "Patching kmscon configuration file (${CFGFILE}) with new colors..."
 
   updateKmsconConfig "$CFGFILE" "$COLOR_01"         "palette-black"
   updateKmsconConfig "$CFGFILE" "$COLOR_02"         "palette-red"
@@ -662,7 +683,7 @@ apply_kmscon() {
   updateKmsconConfig "$CFGFILE" "$BACKGROUND_COLOR" "palette-background"
   updateKmsconConfig "$CFGFILE" "$FOREGROUND_COLOR" "palette-foreground"
 
-  echo "Done - please restart your kmscon vt to see changes"
+  prints "Done - please restart your kmscon vt to see changes"
 }
 
 apply_konsole() {
@@ -683,7 +704,7 @@ apply_konsole() {
 
   KPROFILE="${KDIR}/${PROFILE_NAME}.profile"
   if [[ -f "${KPROFILE}" ]]; then
-      echo "Profile ${PROFILE_NAME} already exists in Konsole confiuration (${KONSOLE_DIR}); Skipping ..."
+      prints "Profile ${PROFILE_NAME} already exists in Konsole confiuration (${KONSOLE_DIR}); Skipping ..."
       exit 0
   fi
 
@@ -693,7 +714,7 @@ apply_konsole() {
 
   KCOLORSCHEME="${KDIR}/${PROFILE_NAME}.colorscheme"
   if [[ -f "${KCOLORSCHEME}" ]]; then
-      echo "Color Scheme ${PROFILE_NAME} already exists in Konsole confiuration (${KONSOLE_DIR}); Skipping ..."
+      prints "Color Scheme ${PROFILE_NAME} already exists in Konsole confiuration (${KONSOLE_DIR}); Skipping ..."
       exit 0
   fi
 
@@ -769,7 +790,7 @@ apply_gtk() {
   profile_hashes=($(${CONFTOOL} "${PROFILE_LIST_KEY}" | tr "[]'," " "))
   for profile in "${profile_hashes[@]}"; do
     if [[ "$(${CONFTOOL} "${BASE_DIR}${profile}/${VISIBLE_NAME}" | tr -d "'")" == "${PROFILE_NAME}" ]]; then
-      printf '%s\n' "Profile already exists" "Skipping..."
+      print '%s\n' "Profile already exists" "Skipping..."
       exit 0
     fi
   done
@@ -788,34 +809,33 @@ apply_gtk() {
     if [[ -z "$(${DCONF} list ${BASE_DIR%:})" ]]; then
       # Provide a user friendly error text if no saved profile exists, otherwise it will display "Error gconftool not found!"
       #  it could happen on a newly installed system. (happened on CentOS 7)
-      printf '%s\n'                                                                                             \
-      "Error, no saved profiles found!"                                                                         \
+      printserr "Error, no saved profiles found!" \
       "Possible fix, new a profile (Terminal > Edit > Preferences > Profiles > New, then Close) and try again." \
       "You can safely delete the created profile after the installation."
       exit 1
     fi
 
-    BACKGROUND_COLOR=$(gnome_color "$BACKGROUND_COLOR")
-    FOREGROUND_COLOR=$(gnome_color "$FOREGROUND_COLOR")
-    CURSOR_COLOR=$(gnome_color "$CURSOR_COLOR")
+    BACKGROUND_COLOR=$(gnome_color   "$BACKGROUND_COLOR")
+    FOREGROUND_COLOR=$(gnome_color   "$FOREGROUND_COLOR")
+    CURSOR_COLOR=$(gnome_color       "$CURSOR_COLOR")
     HIGHLIGHT_BG_COLOR=$(gnome_color "$HIGHLIGHT_BG_COLOR")
     HIGHLIGHT_FG_COLOR=$(gnome_color "$HIGHLIGHT_FG_COLOR")
-    COLOR_01=$(gnome_color         "$COLOR_01")
-    COLOR_02=$(gnome_color         "$COLOR_02")
-    COLOR_03=$(gnome_color         "$COLOR_03")
-    COLOR_04=$(gnome_color         "$COLOR_04")
-    COLOR_05=$(gnome_color         "$COLOR_05")
-    COLOR_06=$(gnome_color         "$COLOR_06")
-    COLOR_07=$(gnome_color         "$COLOR_07")
-    COLOR_08=$(gnome_color         "$COLOR_08")
-    COLOR_09=$(gnome_color         "$COLOR_09")
-    COLOR_10=$(gnome_color         "$COLOR_10")
-    COLOR_11=$(gnome_color         "$COLOR_11")
-    COLOR_12=$(gnome_color         "$COLOR_12")
-    COLOR_13=$(gnome_color         "$COLOR_13")
-    COLOR_14=$(gnome_color         "$COLOR_14")
-    COLOR_15=$(gnome_color         "$COLOR_15")
-    COLOR_16=$(gnome_color         "$COLOR_16")
+    COLOR_01=$(gnome_color           "$COLOR_01")
+    COLOR_02=$(gnome_color           "$COLOR_02")
+    COLOR_03=$(gnome_color           "$COLOR_03")
+    COLOR_04=$(gnome_color           "$COLOR_04")
+    COLOR_05=$(gnome_color           "$COLOR_05")
+    COLOR_06=$(gnome_color           "$COLOR_06")
+    COLOR_07=$(gnome_color           "$COLOR_07")
+    COLOR_08=$(gnome_color           "$COLOR_08")
+    COLOR_09=$(gnome_color           "$COLOR_09")
+    COLOR_10=$(gnome_color           "$COLOR_10")
+    COLOR_11=$(gnome_color           "$COLOR_11")
+    COLOR_12=$(gnome_color           "$COLOR_12")
+    COLOR_13=$(gnome_color           "$COLOR_13")
+    COLOR_14=$(gnome_color           "$COLOR_14")
+    COLOR_15=$(gnome_color           "$COLOR_15")
+    COLOR_16=$(gnome_color           "$COLOR_16")
 
     # copy existing settings from default profile
     $DCONF dump               "${DEFAULT_KEY}/" | $DCONF load "${PROFILE_KEY}/"
@@ -875,7 +895,11 @@ appy_tilixschemes() {
     if ((LOOP == OPTLENGTH)); then
       cp -f  ${scratchdir}/* "$HOME/.config/tilix/schemes/"
       rm -rf "${scratchdir}"
-      read -r -p "All done - apply new theme? [y/N] " -n 1 TILIX_RES
+      if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+              read -r -p "All done - apply new theme? [y/N] " -n 1 TILIX_RES
+      else
+              TILIX_RES="N"
+      fi
       if [[ ${TILIX_RES::1} =~ ^(y|Y)$ ]]; then
         PROFILE_KEY="${BASE_DIR}${DEFAULT_SLUG}"
         PROFILE_NAME="$(${DCONF} read ${PROFILE_KEY}/visible-name | tr -d \')"
@@ -900,7 +924,7 @@ apply_xfce4-terminal() {
         if [[ -r "${XDG_CONFIG_DIRS%%:*}/Terminal/terminalrc" ]]; then
             cp "${XDG_CONFIG_DIRS%%:*}/Terminal/terminalrc" ${CONFFILE}
         else
-            echo "ERROR: config file not present or not writable!"
+            printserr "ERROR: config file not present or not writable!"
             exit 1
         fi
     fi
@@ -934,7 +958,11 @@ apply_xfce4-terminal() {
     # any of the themes in there. The color settings need to
     # be written there directly.
     if ((LOOP == OPTLENGTH)); then
-        read -r -p "All done - apply new theme? [y/N] " -n 1 XFCE4_APPLY_CURR_THEME
+        if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+            read -r -p "All done - apply new theme? [y/N] " -n 1 XFCE4_APPLY_CURR_THEME
+        else
+            XFCE4_APPLY_CURR_THEME="N"
+        fi
         if [[ ${XFCE4_APPLY_CURR_THEME::1} =~ ^(y|Y)$ ]]; then
             if grep -q "^ColorPalette=" "${CONFFILE}"; then
                 sed -i -r -e "s/^ColorPalette=.*/${L_COLORPALETTE}/" "${CONFFILE}"
@@ -1122,8 +1150,7 @@ case "${TERMINAL}" in
     ;;
 
   * )
-    printf '%s\n'                                             \
-    "Unsupported terminal!"                                   \
+    printserr "Unsupported terminal!"                         \
     ""                                                        \
     "Supported terminals:"                                    \
     "   alacritty"                                            \

--- a/apply-terminator.py
+++ b/apply-terminator.py
@@ -8,11 +8,20 @@ import unicodedata
 
 from configobj import ConfigObj
 
+
+def printerr(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def printout(*args, **kwargs):
+    if not "GOGH_NONINTERACTIVE" in os.environ:
+        print(*args, **kwargs)
+
+
 def main(gogh_conf_theme):
     terminator_conf_file_path = get_terminator_conf_path()
     profile_options = choose_profile()
     update_terminator_conf(terminator_conf_file_path, gogh_conf_theme, profile_options)
-
     
 
 def get_terminator_conf_path():
@@ -39,15 +48,16 @@ def update_terminator_conf(terminator_conf_file_path,gogh_conf_theme,profile_opt
     config['profiles'][profile_options["profile"]]['background_color'] = js['colors']['primary']['background']
     config['profiles'][profile_options["profile"]]['palette'] = js['colors']['pallete']
     config.write()
-    print('')
-    print('We’ve saved your profile! Close and open your terminal to see the changes!')
+    printout('')
+    printout('We’ve saved your profile! Close and open your terminal to see the changes!')
 
 
 def choose_profile():
     profile_answer = ''
     copy_default_config_answer = ''
 
-    profile_answer = strip_accents(input("Enter profile to update/create [default]: ")).strip()
+    if not "GOGH_NONINTERACTIVE" in os.environ:
+        profile_answer = strip_accents(input("Enter profile to update/create [default]: ")).strip()
     if profile_answer.lower() in ['', 'default']:
         profile_answer = 'default'
     else:
@@ -60,7 +70,7 @@ def choose_profile():
                 copy_default_config_answer = 'no'
                 break
             else:
-                print("Ops... Type 'Y' or 'N'.")
+                printout("Ops... Type 'Y' or 'N'.")
     return {"profile": profile_answer, "copy_default_config": copy_default_config_answer}
 
 
@@ -68,8 +78,8 @@ def backup_conf(terminator_conf_file_path):
     now_str = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     backup_path = f'{terminator_conf_file_path}.{now_str}'
     shutil.copyfile(terminator_conf_file_path, backup_path)
-    print('')
-    print('Backup created at '+ backup_path)
+    printout('')
+    printout('Backup created at '+ backup_path)
 
 def strip_accents(s):
    return ''.join(c for c in unicodedata.normalize('NFD', s)

--- a/installs/3024-day.sh
+++ b/installs/3024-day.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#4A4543"   # Foreground (Text)
 
 export CURSOR_COLOR="#4A4543" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/3024-night.sh
+++ b/installs/3024-night.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A5A2A2"   # Foreground (Text)
 
 export CURSOR_COLOR="#A5A2A2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/aci.sh
+++ b/installs/aci.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B4E1FD"   # Foreground (Text)
 
 export CURSOR_COLOR="#B4E1FD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/aco.sh
+++ b/installs/aco.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B4E1FD"   # Foreground (Text)
 
 export CURSOR_COLOR="#B4E1FD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/adventure-time.sh
+++ b/installs/adventure-time.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F8DCC0"   # Foreground (Text)
 
 export CURSOR_COLOR="#F8DCC0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/afterglow.sh
+++ b/installs/afterglow.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D0D0D0"   # Foreground (Text)
 
 export CURSOR_COLOR="#D0D0D0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/alien-blood.sh
+++ b/installs/alien-blood.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#637D75"   # Foreground (Text)
 
 export CURSOR_COLOR="#637D75" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/apprentice.sh
+++ b/installs/apprentice.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BCBCBC"   # Foreground (Text)
 
 export CURSOR_COLOR="#BCBCBC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/argonaut.sh
+++ b/installs/argonaut.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFAF4"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFAF4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/arthur.sh
+++ b/installs/arthur.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DDEEDD"   # Foreground (Text)
 
 export CURSOR_COLOR="#DDEEDD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/atom.sh
+++ b/installs/atom.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C5C8C6"   # Foreground (Text)
 
 export CURSOR_COLOR="#C5C8C6" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/aura.sh
+++ b/installs/aura.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EDECEE"   # Foreground (Text)
 
 export CURSOR_COLOR="#EDECEE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ayu-dark.sh
+++ b/installs/ayu-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B3B1AD"   # Foreground (Text)
 
 export CURSOR_COLOR="#E6B450" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ayu-light.sh
+++ b/installs/ayu-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#575F66"   # Foreground (Text)
 
 export CURSOR_COLOR="#FF9940" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ayu-mirage.sh
+++ b/installs/ayu-mirage.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CBCCC6"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFCC66" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/azu.sh
+++ b/installs/azu.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9E6F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9E6F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/belafonte-day.sh
+++ b/installs/belafonte-day.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#45373C"   # Foreground (Text)
 
 export CURSOR_COLOR="#45373C" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/belafonte-night.sh
+++ b/installs/belafonte-night.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#968C83"   # Foreground (Text)
 
 export CURSOR_COLOR="#968C83" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/bim.sh
+++ b/installs/bim.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A9BED8"   # Foreground (Text)
 
 export CURSOR_COLOR="#A9BED8" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/birds-of-paradise.sh
+++ b/installs/birds-of-paradise.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E0DBB7"   # Foreground (Text)
 
 export CURSOR_COLOR="#E0DBB7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/blazer.sh
+++ b/installs/blazer.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9E6F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9E6F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/blue-dolphin.sh
+++ b/installs/blue-dolphin.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C5F2FF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFCC00" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/bluloco-light.sh
+++ b/installs/bluloco-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#383A42"   # Foreground (Text)
 
 export CURSOR_COLOR="#383A42" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/bluloco-zsh-light.sh
+++ b/installs/bluloco-zsh-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#383A42"   # Foreground (Text)
 
 export CURSOR_COLOR="#383A42" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/borland.sh
+++ b/installs/borland.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFF4E"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFF4E" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/breath-darker.sh
+++ b/installs/breath-darker.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#17A88B"   # Foreground (Text)
 
 export CURSOR_COLOR="#17A88B" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/breath-light.sh
+++ b/installs/breath-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#292F34"   # Foreground (Text)
 
 export CURSOR_COLOR="#292F34" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/breath-silverfox.sh
+++ b/installs/breath-silverfox.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BBBBBB"   # Foreground (Text)
 
 export CURSOR_COLOR="#BBBBBB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/breath.sh
+++ b/installs/breath.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#17A88B"   # Foreground (Text)
 
 export CURSOR_COLOR="#17A88B" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/breeze.sh
+++ b/installs/breeze.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FCFCFC"   # Foreground (Text)
 
 export CURSOR_COLOR="#FCFCFC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/broadcast.sh
+++ b/installs/broadcast.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E6E1DC"   # Foreground (Text)
 
 export CURSOR_COLOR="#E6E1DC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/brogrammer.sh
+++ b/installs/brogrammer.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D6DBE5"   # Foreground (Text)
 
 export CURSOR_COLOR="#D6DBE5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/butrin.sh
+++ b/installs/butrin.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#E39D93" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/c64.sh
+++ b/installs/c64.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#7869C4"   # Foreground (Text)
 
 export CURSOR_COLOR="#7869C4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/cai.sh
+++ b/installs/cai.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9E6F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9E6F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/campbell.sh
+++ b/installs/campbell.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CCCCCC"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/catppuccin-frappe.sh
+++ b/installs/catppuccin-frappe.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C6D0F5"   # Foreground (Text)
 
 export CURSOR_COLOR="#C6D0F5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/catppuccin-latte.sh
+++ b/installs/catppuccin-latte.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#4C4F69"   # Foreground (Text)
 
 export CURSOR_COLOR="#4C4F69" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/catppuccin-macchiato.sh
+++ b/installs/catppuccin-macchiato.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CAD3F5"   # Foreground (Text)
 
 export CURSOR_COLOR="#CAD3F5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/catppuccin-mocha.sh
+++ b/installs/catppuccin-mocha.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CDD6F4"   # Foreground (Text)
 
 export CURSOR_COLOR="#CDD6F4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/chalk.sh
+++ b/installs/chalk.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D4D4D4"   # Foreground (Text)
 
 export CURSOR_COLOR="#D4D4D4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/chalkboard.sh
+++ b/installs/chalkboard.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9E6F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9E6F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/chameleon.sh
+++ b/installs/chameleon.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DEDEDE"   # Foreground (Text)
 
 export CURSOR_COLOR="#DEDEDE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ciapre.sh
+++ b/installs/ciapre.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#AEA47A"   # Foreground (Text)
 
 export CURSOR_COLOR="#AEA47A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/clone-of-ubuntu.sh
+++ b/installs/clone-of-ubuntu.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/clrs.sh
+++ b/installs/clrs.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#262626"   # Foreground (Text)
 
 export CURSOR_COLOR="#262626" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/cobalt-2.sh
+++ b/installs/cobalt-2.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/cobalt-neon.sh
+++ b/installs/cobalt-neon.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#8FF586"   # Foreground (Text)
 
 export CURSOR_COLOR="#8FF586" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/colorcli.sh
+++ b/installs/colorcli.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#005F87"   # Foreground (Text)
 
 export CURSOR_COLOR="#005F87" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/crayon-pony-fish.sh
+++ b/installs/crayon-pony-fish.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#68525A"   # Foreground (Text)
 
 export CURSOR_COLOR="#68525A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/dark-pastel.sh
+++ b/installs/dark-pastel.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/darkside.sh
+++ b/installs/darkside.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BABABA"   # Foreground (Text)
 
 export CURSOR_COLOR="#BABABA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/dehydration.sh
+++ b/installs/dehydration.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CCCCCC"   # Foreground (Text)
 
 export CURSOR_COLOR="#CCCCCC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/desert.sh
+++ b/installs/desert.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/dimmed-monokai.sh
+++ b/installs/dimmed-monokai.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B9BCBA"   # Foreground (Text)
 
 export CURSOR_COLOR="#B9BCBA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/dissonance.sh
+++ b/installs/dissonance.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#DC322F" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/dracula.sh
+++ b/installs/dracula.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#f8f8f2"   # Foreground (Text)
 
 export CURSOR_COLOR="#f8f8f2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/earthsong.sh
+++ b/installs/earthsong.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E5C7A9"   # Foreground (Text)
 
 export CURSOR_COLOR="#E5C7A9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/elemental.sh
+++ b/installs/elemental.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#807A74"   # Foreground (Text)
 
 export CURSOR_COLOR="#807A74" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/elementary.sh
+++ b/installs/elementary.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#F2F2F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/elic.sh
+++ b/installs/elic.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#F2F2F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/elio.sh
+++ b/installs/elio.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#F2F2F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/espresso-libre.sh
+++ b/installs/espresso-libre.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B8A898"   # Foreground (Text)
 
 export CURSOR_COLOR="#B8A898" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/espresso.sh
+++ b/installs/espresso.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everblush.sh
+++ b/installs/everblush.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DADADA"   # Foreground (Text)
 
 export CURSOR_COLOR="#DADADA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everforest-dark-hard.sh
+++ b/installs/everforest-dark-hard.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D3C6AA"   # Foreground (Text)
 
 export CURSOR_COLOR="#D3C6AA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everforest-dark-medium.sh
+++ b/installs/everforest-dark-medium.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D3C6AA"   # Foreground (Text)
 
 export CURSOR_COLOR="#D3C6AA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everforest-dark-soft.sh
+++ b/installs/everforest-dark-soft.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D3C6AA"   # Foreground (Text)
 
 export CURSOR_COLOR="#D3C6AA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everforest-light-hard.sh
+++ b/installs/everforest-light-hard.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#5C6A72"   # Foreground (Text)
 
 export CURSOR_COLOR="#5C6A72" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everforest-light-medium.sh
+++ b/installs/everforest-light-medium.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#5C6A72"   # Foreground (Text)
 
 export CURSOR_COLOR="#5C6A72" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/everforest-light-soft.sh
+++ b/installs/everforest-light-soft.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#5C6A72"   # Foreground (Text)
 
 export CURSOR_COLOR="#5C6A72" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/fairy-floss-dark.sh
+++ b/installs/fairy-floss-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C2FFDF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFB8D1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/fairy-floss.sh
+++ b/installs/fairy-floss.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C2FFDF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFB8D1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/fishtank.sh
+++ b/installs/fishtank.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ECF0FE"   # Foreground (Text)
 
 export CURSOR_COLOR="#ECF0FE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/flat-remix.sh
+++ b/installs/flat-remix.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/flat.sh
+++ b/installs/flat.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#1ABC9C"   # Foreground (Text)
 
 export CURSOR_COLOR="#1ABC9C" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/flatland.sh
+++ b/installs/flatland.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B8DBEF"   # Foreground (Text)
 
 export CURSOR_COLOR="#B8DBEF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/foxnightly.sh
+++ b/installs/foxnightly.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D7D7DB"   # Foreground (Text)
 
 export CURSOR_COLOR="#D7D7DB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/freya.sh
+++ b/installs/freya.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#94A3A5"   # Foreground (Text)
 
 export CURSOR_COLOR="#839496" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/frontend-delight.sh
+++ b/installs/frontend-delight.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ADADAD"   # Foreground (Text)
 
 export CURSOR_COLOR="#ADADAD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/frontend-fun-forrest.sh
+++ b/installs/frontend-fun-forrest.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DEC165"   # Foreground (Text)
 
 export CURSOR_COLOR="#DEC165" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/frontend-galaxy.sh
+++ b/installs/frontend-galaxy.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/geohot.sh
+++ b/installs/geohot.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/github-dark.sh
+++ b/installs/github-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#8B949E"   # Foreground (Text)
 
 export CURSOR_COLOR="#C9D1D9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/github-light.sh
+++ b/installs/github-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#1f2328"   # Foreground (Text)
 
 export CURSOR_COLOR="#1f2328" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/gogh.sh
+++ b/installs/gogh.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BFC7D5"   # Foreground (Text)
 
 export CURSOR_COLOR="#BFC7D5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/gooey.sh
+++ b/installs/gooey.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EBEEF9"   # Foreground (Text)
 
 export CURSOR_COLOR="#EBEEF9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/google-dark.sh
+++ b/installs/google-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E8EAED"   # Foreground (Text)
 
 export CURSOR_COLOR="#E8EAED" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/google-light.sh
+++ b/installs/google-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#5F6368"   # Foreground (Text)
 
 export CURSOR_COLOR="#5F6368" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/gotham.sh
+++ b/installs/gotham.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#98D1CE"   # Foreground (Text)
 
 export CURSOR_COLOR="#98D1CE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/grape.sh
+++ b/installs/grape.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#9F9FA1"   # Foreground (Text)
 
 export CURSOR_COLOR="#9F9FA1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/grass.sh
+++ b/installs/grass.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFF0A5"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFF0A5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/gruvbox-dark.sh
+++ b/installs/gruvbox-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EBDBB2"   # Foreground (Text)
 
 export CURSOR_COLOR="#EBDBB2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/gruvbox-material.sh
+++ b/installs/gruvbox-material.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D4BE98"   # Foreground (Text)
 
 export CURSOR_COLOR="#D4BE98" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/gruvbox.sh
+++ b/installs/gruvbox.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#3C3836"   # Foreground (Text)
 
 export CURSOR_COLOR="#3C3836" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/hardcore.sh
+++ b/installs/hardcore.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A0A0A0"   # Foreground (Text)
 
 export CURSOR_COLOR="#A0A0A0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/harper.sh
+++ b/installs/harper.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A8A49D"   # Foreground (Text)
 
 export CURSOR_COLOR="#A8A49D" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/hemisu-dark.sh
+++ b/installs/hemisu-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#BAFFAA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/hemisu-light.sh
+++ b/installs/hemisu-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#444444"   # Foreground (Text)
 
 export CURSOR_COLOR="#FF0054" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/highway.sh
+++ b/installs/highway.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EDEDED"   # Foreground (Text)
 
 export CURSOR_COLOR="#EDEDED" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/hipster-green.sh
+++ b/installs/hipster-green.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#84C138"   # Foreground (Text)
 
 export CURSOR_COLOR="#84C138" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/homebrew-light.sh
+++ b/installs/homebrew-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#000000"   # Foreground (Text)
 
 export CURSOR_COLOR="#000000" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/homebrew-ocean.sh
+++ b/installs/homebrew-ocean.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/homebrew.sh
+++ b/installs/homebrew.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#00FF00"   # Foreground (Text)
 
 export CURSOR_COLOR="#00FF00" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/horizon-bright.sh
+++ b/installs/horizon-bright.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#1C1E26"   # Foreground (Text)
 
 export CURSOR_COLOR="#1C1E26" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/horizon-dark.sh
+++ b/installs/horizon-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FDF0ED"   # Foreground (Text)
 
 export CURSOR_COLOR="#FDF0ED" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/hurtado.sh
+++ b/installs/hurtado.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DBDBDB"   # Foreground (Text)
 
 export CURSOR_COLOR="#DBDBDB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/hybrid.sh
+++ b/installs/hybrid.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#94A3A5"   # Foreground (Text)
 
 export CURSOR_COLOR="#94A3A5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ibm-3270-high-contrast.sh
+++ b/installs/ibm-3270-high-contrast.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FDFDFD"   # Foreground (Text)
 
 export CURSOR_COLOR="#FDFDFD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ibm3270.sh
+++ b/installs/ibm3270.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FDFDFD"   # Foreground (Text)
 
 export CURSOR_COLOR="#FDFDFD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ic-green-ppl.sh
+++ b/installs/ic-green-ppl.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9EFD3"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9EFD3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ic-orange-ppl.sh
+++ b/installs/ic-orange-ppl.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFCB83"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFCB83" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/iceberg.sh
+++ b/installs/iceberg.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#c6c8d1"   # Foreground (Text)
 
 export CURSOR_COLOR="#d2d4de" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/idle-toes.sh
+++ b/installs/idle-toes.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ir-black.sh
+++ b/installs/ir-black.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EEEEEE"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFA560" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/jackie-brown.sh
+++ b/installs/jackie-brown.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFCC2F"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFCC2F" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/japanesque.sh
+++ b/installs/japanesque.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F7F6EC"   # Foreground (Text)
 
 export CURSOR_COLOR="#F7F6EC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/jellybeans.sh
+++ b/installs/jellybeans.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DEDEDE"   # Foreground (Text)
 
 export CURSOR_COLOR="#DEDEDE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/jup.sh
+++ b/installs/jup.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#23476A"   # Foreground (Text)
 
 export CURSOR_COLOR="#23476A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/kanagawa-dragon.sh
+++ b/installs/kanagawa-dragon.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C5C9C5"   # Foreground (Text)
 
 export CURSOR_COLOR="#C8C093" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/kanagawa.sh
+++ b/installs/kanagawa.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DCD7BA"   # Foreground (Text)
 
 export CURSOR_COLOR="#DCD7BA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/kibble.sh
+++ b/installs/kibble.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F7F7F7"   # Foreground (Text)
 
 export CURSOR_COLOR="#F7F7F7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/kokuban.sh
+++ b/installs/kokuban.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D8E2D7"   # Foreground (Text)
 
 export CURSOR_COLOR="#D8E2D7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/laserwave.sh
+++ b/installs/laserwave.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E0E0E0"   # Foreground (Text)
 
 export CURSOR_COLOR="#C7C7C7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/later-this-evening.sh
+++ b/installs/later-this-evening.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#959595"   # Foreground (Text)
 
 export CURSOR_COLOR="#959595" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/lavandula.sh
+++ b/installs/lavandula.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#736E7D"   # Foreground (Text)
 
 export CURSOR_COLOR="#736E7D" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/liquid-carbon-transparent.sh
+++ b/installs/liquid-carbon-transparent.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#AFC2C2"   # Foreground (Text)
 
 export CURSOR_COLOR="#AFC2C2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/liquid-carbon.sh
+++ b/installs/liquid-carbon.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#AFC2C2"   # Foreground (Text)
 
 export CURSOR_COLOR="#AFC2C2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/lunaria-dark.sh
+++ b/installs/lunaria-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CACED8"   # Foreground (Text)
 
 export CURSOR_COLOR="#CACED8" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/lunaria-eclipse.sh
+++ b/installs/lunaria-eclipse.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C9CDD7"   # Foreground (Text)
 
 export CURSOR_COLOR="#C9CDD7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/lunaria-light.sh
+++ b/installs/lunaria-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#484646"   # Foreground (Text)
 
 export CURSOR_COLOR="#484646" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/maia.sh
+++ b/installs/maia.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BDC3C7"   # Foreground (Text)
 
 export CURSOR_COLOR="#BDC3C7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/man-page.sh
+++ b/installs/man-page.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#000000"   # Foreground (Text)
 
 export CURSOR_COLOR="#000000" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mar.sh
+++ b/installs/mar.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#23476A"   # Foreground (Text)
 
 export CURSOR_COLOR="#23476A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/material.sh
+++ b/installs/material.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C3C7D1"   # Foreground (Text)
 
 export CURSOR_COLOR="#657B83" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mathias.sh
+++ b/installs/mathias.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BBBBBB"   # Foreground (Text)
 
 export CURSOR_COLOR="#BBBBBB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/medallion.sh
+++ b/installs/medallion.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CAC296"   # Foreground (Text)
 
 export CURSOR_COLOR="#CAC296" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/miramare.sh
+++ b/installs/miramare.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#e6d6ac"   # Foreground (Text)
 
 export CURSOR_COLOR="#e6d6ac" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/misterioso.sh
+++ b/installs/misterioso.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E1E1E0"   # Foreground (Text)
 
 export CURSOR_COLOR="#E1E1E0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/modus-operandi-tinted.sh
+++ b/installs/modus-operandi-tinted.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#000000"   # Foreground (Text)
 
 export CURSOR_COLOR="#000000" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/modus-operandi.sh
+++ b/installs/modus-operandi.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#000000"   # Foreground (Text)
 
 export CURSOR_COLOR="#000000" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/modus-vivendi-tinted.sh
+++ b/installs/modus-vivendi-tinted.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ffffff"   # Foreground (Text)
 
 export CURSOR_COLOR="#ffffff" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/modus-vivendi.sh
+++ b/installs/modus-vivendi.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ffffff"   # Foreground (Text)
 
 export CURSOR_COLOR="#ffffff" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/molokai.sh
+++ b/installs/molokai.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BBBBBB"   # Foreground (Text)
 
 export CURSOR_COLOR="#BBBBBB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mona-lisa.sh
+++ b/installs/mona-lisa.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F7D66A"   # Foreground (Text)
 
 export CURSOR_COLOR="#F7D66A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mono-amber.sh
+++ b/installs/mono-amber.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FF9400"   # Foreground (Text)
 
 export CURSOR_COLOR="#FF9400" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mono-cyan.sh
+++ b/installs/mono-cyan.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#00CCFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#00CCFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mono-green.sh
+++ b/installs/mono-green.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#0BFF00"   # Foreground (Text)
 
 export CURSOR_COLOR="#0BFF00" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mono-red.sh
+++ b/installs/mono-red.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FF3600"   # Foreground (Text)
 
 export CURSOR_COLOR="#FF3600" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mono-white.sh
+++ b/installs/mono-white.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FAFAFA"   # Foreground (Text)
 
 export CURSOR_COLOR="#FAFAFA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/mono-yellow.sh
+++ b/installs/mono-yellow.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFD300"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFD300" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/monokai-dark.sh
+++ b/installs/monokai-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F8F8F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#F8F8F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/monokai-pro-ristretto.sh
+++ b/installs/monokai-pro-ristretto.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FBF2F3"   # Foreground (Text)
 
 export CURSOR_COLOR="#FBF2F3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/monokai-pro.sh
+++ b/installs/monokai-pro.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FDF9F3"   # Foreground (Text)
 
 export CURSOR_COLOR="#FDF9F3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/monokai-soda.sh
+++ b/installs/monokai-soda.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C4C5B5"   # Foreground (Text)
 
 export CURSOR_COLOR="#C4C5B5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/moonfly.sh
+++ b/installs/moonfly.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BDBDBD"   # Foreground (Text)
 
 export CURSOR_COLOR="#9E9E9E" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/morada.sh
+++ b/installs/morada.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/n0tch2k.sh
+++ b/installs/n0tch2k.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A0A0A0"   # Foreground (Text)
 
 export CURSOR_COLOR="#A0A0A0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/neon-night.sh
+++ b/installs/neon-night.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C7C8FF"   # Foreground (Text)
 
 export CURSOR_COLOR="#C7C8FF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/neopolitan.sh
+++ b/installs/neopolitan.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nep.sh
+++ b/installs/nep.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#23476A"   # Foreground (Text)
 
 export CURSOR_COLOR="#23476A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/neutron.sh
+++ b/installs/neutron.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E6E8EF"   # Foreground (Text)
 
 export CURSOR_COLOR="#E6E8EF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/night-owl.sh
+++ b/installs/night-owl.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D6DEEB"   # Foreground (Text)
 
 export CURSOR_COLOR="#D6DEEB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nightfly.sh
+++ b/installs/nightfly.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BDC1C6"   # Foreground (Text)
 
 export CURSOR_COLOR="#9CA1AA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nightlion-v1.sh
+++ b/installs/nightlion-v1.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BBBBBB"   # Foreground (Text)
 
 export CURSOR_COLOR="#BBBBBB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nightlion-v2.sh
+++ b/installs/nightlion-v2.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BBBBBB"   # Foreground (Text)
 
 export CURSOR_COLOR="#BBBBBB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nighty.sh
+++ b/installs/nighty.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DFDFDF"   # Foreground (Text)
 
 export CURSOR_COLOR="#DFDFDF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nord-light.sh
+++ b/installs/nord-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#004F7C"   # Foreground (Text)
 
 export CURSOR_COLOR="#439ECF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/nord.sh
+++ b/installs/nord.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D8DEE9"   # Foreground (Text)
 
 export CURSOR_COLOR="#D8DEE9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/novel.sh
+++ b/installs/novel.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#3B2322"   # Foreground (Text)
 
 export CURSOR_COLOR="#3B2322" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/obsidian.sh
+++ b/installs/obsidian.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CDCDCD"   # Foreground (Text)
 
 export CURSOR_COLOR="#CDCDCD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ocean-dark.sh
+++ b/installs/ocean-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#979CAC"   # Foreground (Text)
 
 export CURSOR_COLOR="#979CAC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/oceanic-next.sh
+++ b/installs/oceanic-next.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B3B8C3"   # Foreground (Text)
 
 export CURSOR_COLOR="#B3B8C3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ollie.sh
+++ b/installs/ollie.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#8A8DAE"   # Foreground (Text)
 
 export CURSOR_COLOR="#8A8DAE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/omni.sh
+++ b/installs/omni.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ABB2BF"   # Foreground (Text)
 
 export CURSOR_COLOR="#ABB2BF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/one-dark.sh
+++ b/installs/one-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#5C6370"   # Foreground (Text)
 
 export CURSOR_COLOR="#5C6370" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/one-half-black.sh
+++ b/installs/one-half-black.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DCDFE4"   # Foreground (Text)
 
 export CURSOR_COLOR="#DCDFE4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/one-light.sh
+++ b/installs/one-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#2A2B32"   # Foreground (Text)
 
 export CURSOR_COLOR="#2A2B32" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/oxocarbon-dark.sh
+++ b/installs/oxocarbon-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#6F6F6F" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/palenight.sh
+++ b/installs/palenight.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BFC7D5"   # Foreground (Text)
 
 export CURSOR_COLOR="#BFC7D5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/pali.sh
+++ b/installs/pali.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9E6F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9E6F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/panda.sh
+++ b/installs/panda.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F0F0F0"   # Foreground (Text)
 
 export CURSOR_COLOR="#F0F0F0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/paper.sh
+++ b/installs/paper.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#000000"   # Foreground (Text)
 
 export CURSOR_COLOR="#000000" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/papercolor-dark.sh
+++ b/installs/papercolor-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D0D0D0"   # Foreground (Text)
 
 export CURSOR_COLOR="#D0D0D0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/papercolor-light.sh
+++ b/installs/papercolor-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#444444"   # Foreground (Text)
 
 export CURSOR_COLOR="#444444" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/paraiso-dark.sh
+++ b/installs/paraiso-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A39E9B"   # Foreground (Text)
 
 export CURSOR_COLOR="#A39E9B" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/paul-millr.sh
+++ b/installs/paul-millr.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#F2F2F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/pencil-dark.sh
+++ b/installs/pencil-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F1F1F1"   # Foreground (Text)
 
 export CURSOR_COLOR="#F1F1F1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/pencil-light.sh
+++ b/installs/pencil-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#424242"   # Foreground (Text)
 
 export CURSOR_COLOR="#424242" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/peppermint.sh
+++ b/installs/peppermint.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C7C7C7"   # Foreground (Text)
 
 export CURSOR_COLOR="#BBBBBB" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/pixiefloss.sh
+++ b/installs/pixiefloss.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D1CAE8"   # Foreground (Text)
 
 export CURSOR_COLOR="#D1CAE8" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/pnevma.sh
+++ b/installs/pnevma.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D0D0D0"   # Foreground (Text)
 
 export CURSOR_COLOR="#D0D0D0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/powershell.sh
+++ b/installs/powershell.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F6F6F7"   # Foreground (Text)
 
 export CURSOR_COLOR="#F6F6F7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/predawn.sh
+++ b/installs/predawn.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F1F1F1"   # Foreground (Text)
 
 export CURSOR_COLOR="#F1F1F1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/pro.sh
+++ b/installs/pro.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#F2F2F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/purple-people-eater.sh
+++ b/installs/purple-people-eater.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C9D1D9"   # Foreground (Text)
 
 export CURSOR_COLOR="#C9D1D9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/quiet.sh
+++ b/installs/quiet.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B9B9B9"   # Foreground (Text)
 
 export CURSOR_COLOR="#A0A0A0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/red-alert.sh
+++ b/installs/red-alert.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/red-sands.sh
+++ b/installs/red-sands.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D7C9A7"   # Foreground (Text)
 
 export CURSOR_COLOR="#D7C9A7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/relaxed.sh
+++ b/installs/relaxed.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9D9D9"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9D9D9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/rippedcasts.sh
+++ b/installs/rippedcasts.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/rose-pine-dawn.sh
+++ b/installs/rose-pine-dawn.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#575279"   # Foreground (Text)
 
 export CURSOR_COLOR="#575279" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/rose-pine-moon.sh
+++ b/installs/rose-pine-moon.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E0DEF4"   # Foreground (Text)
 
 export CURSOR_COLOR="#E0DEF4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/rose-pine.sh
+++ b/installs/rose-pine.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E0DEF4"   # Foreground (Text)
 
 export CURSOR_COLOR="#E0DEF4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/royal.sh
+++ b/installs/royal.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#514968"   # Foreground (Text)
 
 export CURSOR_COLOR="#514968" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sat.sh
+++ b/installs/sat.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#23476A"   # Foreground (Text)
 
 export CURSOR_COLOR="#23476A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sea-shells.sh
+++ b/installs/sea-shells.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DEB88D"   # Foreground (Text)
 
 export CURSOR_COLOR="#DEB88D" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/seafoam-pastel.sh
+++ b/installs/seafoam-pastel.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D4E7D4"   # Foreground (Text)
 
 export CURSOR_COLOR="#D4E7D4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/selenized-black.sh
+++ b/installs/selenized-black.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#b9b9b9"   # Foreground (Text)
 
 export CURSOR_COLOR="#dedede" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/selenized-dark.sh
+++ b/installs/selenized-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#adbcbc"   # Foreground (Text)
 
 export CURSOR_COLOR="#cad8d9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/selenized-light.sh
+++ b/installs/selenized-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#53676d"   # Foreground (Text)
 
 export CURSOR_COLOR="#3a4d53" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/selenized-white.sh
+++ b/installs/selenized-white.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#474747"   # Foreground (Text)
 
 export CURSOR_COLOR="#282828" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/seoul256-light.sh
+++ b/installs/seoul256-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#4e4e4e"   # Foreground (Text)
 
 export CURSOR_COLOR="#4e4e4e" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/seoul256.sh
+++ b/installs/seoul256.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#d0d0d0"   # Foreground (Text)
 
 export CURSOR_COLOR="#d0d0d0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/seti.sh
+++ b/installs/seti.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CACECD"   # Foreground (Text)
 
 export CURSOR_COLOR="#CACECD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/shaman.sh
+++ b/installs/shaman.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#405555"   # Foreground (Text)
 
 export CURSOR_COLOR="#405555" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/shel.sh
+++ b/installs/shel.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#4882CD"   # Foreground (Text)
 
 export CURSOR_COLOR="#4882CD" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/slate.sh
+++ b/installs/slate.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#35B1D2"   # Foreground (Text)
 
 export CURSOR_COLOR="#35B1D2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/smyck.sh
+++ b/installs/smyck.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F7F7F7"   # Foreground (Text)
 
 export CURSOR_COLOR="#F7F7F7" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/snazzy.sh
+++ b/installs/snazzy.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EFF0EB"   # Foreground (Text)
 
 export CURSOR_COLOR="#97979B" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/soft-server.sh
+++ b/installs/soft-server.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#99A3A2"   # Foreground (Text)
 
 export CURSOR_COLOR="#99A3A2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/solarized-darcula.sh
+++ b/installs/solarized-darcula.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D2D8D9"   # Foreground (Text)
 
 export CURSOR_COLOR="#D2D8D9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/solarized-dark-higher-contrast.sh
+++ b/installs/solarized-dark-higher-contrast.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#9CC2C3"   # Foreground (Text)
 
 export CURSOR_COLOR="#9CC2C3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/solarized-dark.sh
+++ b/installs/solarized-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#839496"   # Foreground (Text)
 
 export CURSOR_COLOR="#839496" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/solarized-light.sh
+++ b/installs/solarized-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#657B83"   # Foreground (Text)
 
 export CURSOR_COLOR="#657B83" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sonokai.sh
+++ b/installs/sonokai.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E2E2E3"   # Foreground (Text)
 
 export CURSOR_COLOR="#E2E2E3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/spacedust.sh
+++ b/installs/spacedust.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ECF0C1"   # Foreground (Text)
 
 export CURSOR_COLOR="#ECF0C1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/spacegray-eighties-dull.sh
+++ b/installs/spacegray-eighties-dull.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C9C6BC"   # Foreground (Text)
 
 export CURSOR_COLOR="#C9C6BC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/spacegray-eighties.sh
+++ b/installs/spacegray-eighties.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#BDBAAE"   # Foreground (Text)
 
 export CURSOR_COLOR="#BDBAAE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/spacegray.sh
+++ b/installs/spacegray.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B3B8C3"   # Foreground (Text)
 
 export CURSOR_COLOR="#B3B8C3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sparky.sh
+++ b/installs/sparky.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F4F5F0"   # Foreground (Text)
 
 export CURSOR_COLOR="#F4F5F0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/spring.sh
+++ b/installs/spring.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#ECF0C1"   # Foreground (Text)
 
 export CURSOR_COLOR="#ECF0C1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/square.sh
+++ b/installs/square.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#A1A1A1"   # Foreground (Text)
 
 export CURSOR_COLOR="#A1A1A1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/srcery.sh
+++ b/installs/srcery.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FCE8C3"   # Foreground (Text)
 
 export CURSOR_COLOR="#FBB829" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/summer-pop.sh
+++ b/installs/summer-pop.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sundried.sh
+++ b/installs/sundried.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C9C9C9"   # Foreground (Text)
 
 export CURSOR_COLOR="#C9C9C9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sweet-eliverlara.sh
+++ b/installs/sweet-eliverlara.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C3C7D1"   # Foreground (Text)
 
 export CURSOR_COLOR="#C3C7D1" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/sweet-terminal.sh
+++ b/installs/sweet-terminal.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/symphonic.sh
+++ b/installs/symphonic.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/synthwave-alpha.sh
+++ b/installs/synthwave-alpha.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F2F2E3"   # Foreground (Text)
 
 export CURSOR_COLOR="#F2F2E3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/synthwave.sh
+++ b/installs/synthwave.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#03EDF9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/teerb.sh
+++ b/installs/teerb.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D0D0D0"   # Foreground (Text)
 
 export CURSOR_COLOR="#D0D0D0" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tender.sh
+++ b/installs/tender.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#EEEEEE"   # Foreground (Text)
 
 export CURSOR_COLOR="#EEEEEE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/terminal-basic.sh
+++ b/installs/terminal-basic.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#000000"   # Foreground (Text)
 
 export CURSOR_COLOR="#7f7f7f" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/terminix-dark.sh
+++ b/installs/terminix-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#868A8C"   # Foreground (Text)
 
 export CURSOR_COLOR="#868A8C" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/thayer-bright.sh
+++ b/installs/thayer-bright.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#F8F8F8"   # Foreground (Text)
 
 export CURSOR_COLOR="#F8F8F8" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tin.sh
+++ b/installs/tin.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tokyo-night-light.sh
+++ b/installs/tokyo-night-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#565A6E"   # Foreground (Text)
 
 export CURSOR_COLOR="#565A6E" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tokyo-night-storm.sh
+++ b/installs/tokyo-night-storm.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C0CAF5"   # Foreground (Text)
 
 export CURSOR_COLOR="#C0CAF5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tokyo-night.sh
+++ b/installs/tokyo-night.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C0CAF5"   # Foreground (Text)
 
 export CURSOR_COLOR="#C0CAF5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tomorrow-night-blue.sh
+++ b/installs/tomorrow-night-blue.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFEFE"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFEFE" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tomorrow-night-bright.sh
+++ b/installs/tomorrow-night-bright.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#E9E9E9"   # Foreground (Text)
 
 export CURSOR_COLOR="#E9E9E9" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tomorrow-night-eighties.sh
+++ b/installs/tomorrow-night-eighties.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CCCCCC"   # Foreground (Text)
 
 export CURSOR_COLOR="#CCCCCC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tomorrow-night.sh
+++ b/installs/tomorrow-night.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#C5C8C6"   # Foreground (Text)
 
 export CURSOR_COLOR="#C4C8C5" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/tomorrow.sh
+++ b/installs/tomorrow.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#4D4D4C"   # Foreground (Text)
 
 export CURSOR_COLOR="#4C4C4C" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/toy-chest.sh
+++ b/installs/toy-chest.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#31D07B"   # Foreground (Text)
 
 export CURSOR_COLOR="#31D07B" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/treehouse.sh
+++ b/installs/treehouse.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#786B53"   # Foreground (Text)
 
 export CURSOR_COLOR="#786B53" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/twilight.sh
+++ b/installs/twilight.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFD4"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFD4" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/ura.sh
+++ b/installs/ura.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#23476A"   # Foreground (Text)
 
 export CURSOR_COLOR="#23476A" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/urple.sh
+++ b/installs/urple.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#877A9B"   # Foreground (Text)
 
 export CURSOR_COLOR="#877A9B" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/vag.sh
+++ b/installs/vag.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#D9E6F2"   # Foreground (Text)
 
 export CURSOR_COLOR="#D9E6F2" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/vaughn.sh
+++ b/installs/vaughn.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DCDCCC"   # Foreground (Text)
 
 export CURSOR_COLOR="#DCDCCC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/vibrant-ink.sh
+++ b/installs/vibrant-ink.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FFFFFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#FFFFFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/vs-code-dark.sh
+++ b/installs/vs-code-dark.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#CCCCCC"   # Foreground (Text)
 
 export CURSOR_COLOR="#CCCCCC" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/vs-code-light.sh
+++ b/installs/vs-code-light.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#020202"   # Foreground (Text)
 
 export CURSOR_COLOR="#020202" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/warm-neon.sh
+++ b/installs/warm-neon.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#AFDAB6"   # Foreground (Text)
 
 export CURSOR_COLOR="#AFDAB6" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/website.sh
+++ b/installs/website.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#d1b890"   # Foreground (Text)
 
 export CURSOR_COLOR="#d1b890" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/wez.sh
+++ b/installs/wez.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#B3B3B3"   # Foreground (Text)
 
 export CURSOR_COLOR="#B3B3B3" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/wild-cherry.sh
+++ b/installs/wild-cherry.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DAFAFF"   # Foreground (Text)
 
 export CURSOR_COLOR="#DAFAFF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/wombat.sh
+++ b/installs/wombat.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#DEDACF"   # Foreground (Text)
 
 export CURSOR_COLOR="#DEDACF" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/wryan.sh
+++ b/installs/wryan.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#999993"   # Foreground (Text)
 
 export CURSOR_COLOR="#999993" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/wzoreck.sh
+++ b/installs/wzoreck.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#FCFCFA"   # Foreground (Text)
 
 export CURSOR_COLOR="#FCFCFA" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/installs/zenburn.sh
+++ b/installs/zenburn.sh
@@ -25,19 +25,27 @@ export FOREGROUND_COLOR="#dcdccc"   # Foreground (Text)
 
 export CURSOR_COLOR="#dcdccc" # Cursor
 
+apply_theme() {
+    if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
+      bash "${GOGH_APPLY_SCRIPT}"
+    elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
+      bash "${PARENT_PATH}/apply-colors.sh"
+    elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
+      bash "${SCRIPT_PATH}/apply-colors.sh"
+    else
+      printf '\n%s\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${SCRIPT_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 PARENT_PATH="$(dirname "${SCRIPT_PATH}")"
 
-if [[ -e "${GOGH_APPLY_SCRIPT}" ]]; then
-  bash "${GOGH_APPLY_SCRIPT}"
-elif [[ -e "${PARENT_PATH}/apply-colors.sh" ]]; then
-  bash "${PARENT_PATH}/apply-colors.sh"
-elif [[ -e "${SCRIPT_PATH}/apply-colors.sh" ]]; then
-  bash "${SCRIPT_PATH}/apply-colors.sh"
+if [ -z "${GOGH_NONINTERACTIVE+yes}" ]; then
+    apply_theme
 else
-  printf '\n%s\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi

--- a/tools/generateShFiles.py
+++ b/tools/generateShFiles.py
@@ -65,21 +65,29 @@ export FOREGROUND_COLOR="{foreground}"   # Foreground (Text)
 
 export CURSOR_COLOR="{cursorColor}" # Cursor
 
+apply_theme() {{
+    if [[ -e "${{GOGH_APPLY_SCRIPT}}" ]]; then
+      bash "${{GOGH_APPLY_SCRIPT}}"
+    elif [[ -e "${{PARENT_PATH}}/apply-colors.sh" ]]; then
+      bash "${{PARENT_PATH}}/apply-colors.sh"
+    elif [[ -e "${{SCRIPT_PATH}}/apply-colors.sh" ]]; then
+      bash "${{SCRIPT_PATH}}/apply-colors.sh"
+    else
+      printf '\\n%s\\n' "Error: Couldn't find apply-colors.sh" 1>&2
+      exit 1
+    fi
+}}
+
 # | ===========================================================================
 # | Apply Colors
 # | ===========================================================================
 SCRIPT_PATH="${{SCRIPT_PATH:-$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)}}"
 PARENT_PATH="$(dirname "${{SCRIPT_PATH}}")"
 
-if [[ -e "${{GOGH_APPLY_SCRIPT}}" ]]; then
-  bash "${{GOGH_APPLY_SCRIPT}}"
-elif [[ -e "${{PARENT_PATH}}/apply-colors.sh" ]]; then
-  bash "${{PARENT_PATH}}/apply-colors.sh"
-elif [[ -e "${{SCRIPT_PATH}}/apply-colors.sh" ]]; then
-  bash "${{SCRIPT_PATH}}/apply-colors.sh"
+if [ -z "${{GOGH_NONINTERACTIVE+yes}}" ]; then
+    apply_theme
 else
-  printf '\\n%s\\n' "Error: Couldn't find apply-colors.sh"
-  exit 1
+    apply_theme 1>/dev/null
 fi
 """
 


### PR DESCRIPTION
This commit adds the GOGH_NONINTERACTIVE environmental flag to suppress messages but still show errors.

This is quite handy as when running Gogh in non-interactive mode/scripting we don't want to clutter the screen with color and other output

Also prompts are answered automatically with the default value

This closes #440 