### PR TITLE
Add the Breadog theme

### DIFF
--- a/themes/Breadog.yml
+++ b/themes/Breadog.yml
@@ -1,0 +1,25 @@
+---
+name: 'Breadog'
+
+color_01: '#362C24'    # Black (Host)
+color_02: '#B10B00'    # Red (Syntax string)
+color_03: '#007232'    # Green (Command)
+color_04: '#8B4C00'    # Yellow (Command second)
+color_05: '#005CB4'    # Blue (Path)
+color_06: '#9B0097'    # Magenta (Syntax var)
+color_07: '#006A78'    # Cyan (Prompt)
+color_08: '#D4C3B7'    # White
+
+color_09: '#514337'    # Bright Black
+color_10: '#DE1100'    # Bright Red (Command error)
+color_11: '#008F40'    # Bright Green (Exec)
+color_12: '#AE6000'    # Bright Yellow
+color_13: '#0074E1'    # Bright Blue (Folder)
+color_14: '#C300BD'    # Bright Magenta
+color_15: '#008697'    # Bright Cyan
+color_16: '#EAE1DA'    # Bright White
+
+background: '#F1EBE6'  # Background
+foreground: '#362C24'  # Foreground (Text)
+
+cursor: '#362C24'      # Cursor


### PR DESCRIPTION
[Breadog] is a light theme I made with the goal of keeping contrast high, lightness among colors consistent, and the overall appearance pleasant to look at.

[Breadog]: https://gitlab.com/warningnonpotablewater/breadog

Here are some screenshots:

![Palette showcase](https://github.com/Gogh-Co/Gogh/assets/17949857/d0e0b617-7f7c-4a79-8656-b379eb632423)

![Code syntax highlighting showcase](https://github.com/Gogh-Co/Gogh/assets/17949857/b7a9e176-6fc1-484b-aa35-d06b1368f210)