### PR TITLE
fixed Tomorrow themes

### DIFF
--- a/themes/Tomorrow Night Blue.yml
+++ b/themes/Tomorrow Night Blue.yml
@@ -1,25 +1,27 @@
 ---
 name: 'Tomorrow Night Blue'
+author: 'Chris Kempson (http://chriskempson.com)'
+variant: 'dark'
 
-color_01: '#000000'    # Black (Host)
-color_02: '#FF9DA3'    # Red (Syntax string)
+color_01: '#00346E'    # Black (Host)
+color_02: '#FF9DA4'    # Red (Syntax string)
 color_03: '#D1F1A9'    # Green (Command)
 color_04: '#FFEEAD'    # Yellow (Command second)
 color_05: '#BBDAFF'    # Blue (Path)
 color_06: '#EBBBFF'    # Magenta (Syntax var)
 color_07: '#99FFFF'    # Cyan (Prompt)
-color_08: '#FFFEFE'    # White
+color_08: '#FFFFFF'    # White
 
-color_09: '#000000'    # Bright Black
-color_10: '#FF9CA3'    # Bright Red (Command error)
-color_11: '#D0F0A8'    # Bright Green (Exec)
-color_12: '#FFEDAC'    # Bright Yellow
-color_13: '#BADAFF'    # Bright Blue (Folder)
-color_14: '#EBBAFF'    # Bright Magenta
+color_09: '#7285B7'    # Bright Black
+color_10: '#FF9DA4'    # Bright Red (Command error)
+color_11: '#D1F1A9'    # Bright Green (Exec)
+color_12: '#FFEEAD'    # Bright Yellow
+color_13: '#BBDAFF'    # Bright Blue (Folder)
+color_14: '#EBBBFF'    # Bright Magenta
 color_15: '#99FFFF'    # Bright Cyan
-color_16: '#FFFEFE'    # Bright White
+color_16: '#FFFFFF'    # Bright White
 
 background: '#002451'  # Background
-foreground: '#FFFEFE'  # Foreground (Text)
+foreground: '#FFFFFF'  # Foreground (Text)
 
-cursor: '#FFFEFE'      # Cursor
+cursor: '#FFFFFF'      # Cursor

--- a/themes/Tomorrow Night Bright.yml
+++ b/themes/Tomorrow Night Bright.yml
@@ -1,25 +1,27 @@
 ---
 name: 'Tomorrow Night Bright'
+author: 'Chris Kempson (http://chriskempson.com)'
+variant: 'dark'
 
-color_01: '#000000'    # Black (Host)
+color_01: '#2A2A2A'    # Black (Host)
 color_02: '#D54E53'    # Red (Syntax string)
-color_03: '#B9CA49'    # Green (Command)
+color_03: '#B9CA4A'    # Green (Command)
 color_04: '#E7C547'    # Yellow (Command second)
-color_05: '#79A6DA'    # Blue (Path)
+color_05: '#7AA6DA'    # Blue (Path)
 color_06: '#C397D8'    # Magenta (Syntax var)
 color_07: '#70C0B1'    # Cyan (Prompt)
-color_08: '#FFFEFE'    # White
+color_08: '#EAEAEA'    # White
 
-color_09: '#000000'    # Bright Black
-color_10: '#D44D53'    # Bright Red (Command error)
-color_11: '#B9C949'    # Bright Green (Exec)
-color_12: '#E6C446'    # Bright Yellow
-color_13: '#79A6DA'    # Bright Blue (Folder)
-color_14: '#C396D7'    # Bright Magenta
+color_09: '#969896'    # Bright Black
+color_10: '#D54E53'    # Bright Red (Command error)
+color_11: '#B9CA4A'    # Bright Green (Exec)
+color_12: '#E7C547'    # Bright Yellow
+color_13: '#7AA6DA'    # Bright Blue (Folder)
+color_14: '#C397D8'    # Bright Magenta
 color_15: '#70C0B1'    # Bright Cyan
-color_16: '#FFFEFE'    # Bright White
+color_16: '#FFFFFF'    # Bright White
 
 background: '#000000'  # Background
-foreground: '#E9E9E9'  # Foreground (Text)
+foreground: '#EAEAEA'  # Foreground (Text)
 
-cursor: '#E9E9E9'      # Cursor
+cursor: '#EAEAEA'      # Cursor

--- a/themes/Tomorrow Night Eighties.yml
+++ b/themes/Tomorrow Night Eighties.yml
@@ -1,25 +1,27 @@
 ---
 name: 'Tomorrow Night Eighties'
+author: 'Chris Kempson (http://chriskempson.com)'
+variant: 'dark'
 
-color_01: '#000000'    # Black (Host)
-color_02: '#F27779'    # Red (Syntax string)
+color_01: '#393939'    # Black (Host)
+color_02: '#F2777A'    # Red (Syntax string)
 color_03: '#99CC99'    # Green (Command)
 color_04: '#FFCC66'    # Yellow (Command second)
 color_05: '#6699CC'    # Blue (Path)
 color_06: '#CC99CC'    # Magenta (Syntax var)
 color_07: '#66CCCC'    # Cyan (Prompt)
-color_08: '#FFFEFE'    # White
+color_08: '#CCCCCC'    # White
 
-color_09: '#000000'    # Bright Black
-color_10: '#F17779'    # Bright Red (Command error)
+color_09: '#999999'    # Bright Black
+color_10: '#F2777A'    # Bright Red (Command error)
 color_11: '#99CC99'    # Bright Green (Exec)
 color_12: '#FFCC66'    # Bright Yellow
 color_13: '#6699CC'    # Bright Blue (Folder)
 color_14: '#CC99CC'    # Bright Magenta
 color_15: '#66CCCC'    # Bright Cyan
-color_16: '#FFFEFE'    # Bright White
+color_16: '#FFFFFF'    # Bright White
 
-background: '#2C2C2C'  # Background
+background: '#2D2D2D'  # Background
 foreground: '#CCCCCC'  # Foreground (Text)
 
 cursor: '#CCCCCC'      # Cursor

--- a/themes/Tomorrow Night.yml
+++ b/themes/Tomorrow Night.yml
@@ -1,25 +1,27 @@
 ---
 name: 'Tomorrow Night'
+author: 'Chris Kempson (http://chriskempson.com)'
+variant: 'dark'
 
-color_01: '#000000'    # Black (Host)
+color_01: '#282A2E'    # Black (Host)
 color_02: '#CC6666'    # Red (Syntax string)
 color_03: '#B5BD68'    # Green (Command)
 color_04: '#F0C674'    # Yellow (Command second)
 color_05: '#81A2BE'    # Blue (Path)
-color_06: '#B293BB'    # Magenta (Syntax var)
+color_06: '#B294BB'    # Magenta (Syntax var)
 color_07: '#8ABEB7'    # Cyan (Prompt)
-color_08: '#FFFEFE'    # White
+color_08: '#C5C8C6'    # White
 
-color_09: '#808080'    # Bright Black is too Dark for Terminal
+color_09: '#969896'    # Bright Black
 color_10: '#CC6666'    # Bright Red (Command error)
 color_11: '#B5BD68'    # Bright Green (Exec)
-color_12: '#F0C574'    # Bright Yellow
-color_13: '#80A1BD'    # Bright Blue (Folder)
-color_14: '#B294BA'    # Bright Magenta
-color_15: '#8ABDB6'    # Bright Cyan
-color_16: '#FFFEFE'    # Bright White
+color_12: '#F0C674'    # Bright Yellow
+color_13: '#81A2BE'    # Bright Blue (Folder)
+color_14: '#B294BB'    # Bright Magenta
+color_15: '#8ABEB7'    # Bright Cyan
+color_16: '#FFFFFF'    # Bright White
 
 background: '#1D1F21'  # Background
 foreground: '#C5C8C6'  # Foreground (Text)
 
-cursor: '#C4C8C5'      # Cursor
+cursor: '#C5C8C6'      # Cursor

--- a/themes/Tomorrow.yml
+++ b/themes/Tomorrow.yml
@@ -1,25 +1,27 @@
 ---
 name: 'Tomorrow'
+author: 'Chris Kempson (http://chriskempson.com)'
+variant: 'light'
 
-color_01: '#000000'    # Black (Host)
-color_02: '#C82828'    # Red (Syntax string)
+color_01: '#E0E0E0'    # Black (Host)
+color_02: '#C82829'    # Red (Syntax string)
 color_03: '#718C00'    # Green (Command)
 color_04: '#EAB700'    # Yellow (Command second)
-color_05: '#4171AE'    # Blue (Path)
+color_05: '#4271AE'    # Blue (Path)
 color_06: '#8959A8'    # Magenta (Syntax var)
 color_07: '#3E999F'    # Cyan (Prompt)
-color_08: '#FFFEFE'    # White
+color_08: '#4D4D4C'    # White
 
-color_09: '#000000'    # Bright Black
-color_10: '#C82828'    # Bright Red (Command error)
-color_11: '#708B00'    # Bright Green (Exec)
-color_12: '#E9B600'    # Bright Yellow
-color_13: '#4170AE'    # Bright Blue (Folder)
-color_14: '#8958A7'    # Bright Magenta
-color_15: '#3D999F'    # Bright Cyan
-color_16: '#FFFEFE'    # Bright White
+color_09: '#8E908C'    # Bright Black
+color_10: '#C82829'    # Bright Red (Command error)
+color_11: '#718C00'    # Bright Green (Exec)
+color_12: '#EAB700'    # Bright Yellow
+color_13: '#4271AE'    # Bright Blue (Folder)
+color_14: '#8959A8'    # Bright Magenta
+color_15: '#3E999F'    # Bright Cyan
+color_16: '#1D1F21'    # Bright White
 
 background: '#FFFFFF'  # Background
 foreground: '#4D4D4C'  # Foreground (Text)
 
-cursor: '#4C4C4C'      # Cursor
+cursor: '#4D4D4C'      # Cursor


### PR DESCRIPTION
hi. current Tomorrow's themes are broken in many colors. in this pr i fix that.

not sure which was the origin of current colors in Gogh, but here's the most relevant sources i've found from theme author @chriskempson:
- author's vim themes https://github.com/chriskempson/tomorrow-theme/tree/master/vim/colors
- author's generated shell scipts https://github.com/chriskempson/base16-shell/blob/master/scripts/base16-tomorrow-night-eighties.sh (which were then continued in https://github.com/tinted-theming/tinted-shell mostly as is)

in this pr i:
- took all red / green / ... / cyan colors from vim and from base16 if any - this is the simplest part to fix :)
- same thing for fg / gb / cursor (which equals to fg)
- fixed black color01 to be **base01** (and not base00 which equals to bg), or **line** color from vim theme
- fixed brblack color09 to be **base03** (and not pure black or similar), or **comment** color from vim theme
- fixed white to be **base05** (which equals to fg)

here're some screenshots.
Tomorrow current
![Screenshot from 2024-08-24 18-35-27](https://github.com/user-attachments/assets/0a8ce1a1-724c-4679-95ba-76e3e634370b)

Tomorrow fixed
![Uploading Screenshot from 2024-08-24 18-35-34.png…]()

Tomorrow Night current
![Screenshot from 2024-08-24 18-36-05](https://github.com/user-attachments/assets/aa5a6030-7d44-47b8-bc51-3b8327d172ca)

Tomorrow Night fixed
![Screenshot from 2024-08-24 18-36-11](https://github.com/user-attachments/assets/caa25ccd-248a-4a0b-b9bf-39d04a607586)

Tomorrow Night Bright current
![Screenshot from 2024-08-24 18-36-25](https://github.com/user-attachments/assets/8974efa3-38ef-4880-a61a-f874cfe8a470)

Tomorrow Night Bright fixed
![Screenshot from 2024-08-24 18-36-30](https://github.com/user-attachments/assets/68e439f0-419c-407d-afa8-78cb6b2c97b5)

Tomorrow Night Eighties current
![Screenshot from 2024-08-24 18-36-39](https://github.com/user-attachments/assets/112ad485-6aa4-4182-a165-326740e7e689)

Tomorrow Night Eighties fixed
![Screenshot from 2024-08-24 18-36-45](https://github.com/user-attachments/assets/1cd25d83-2b9a-4380-a4ea-181e3750d9aa)

Tomorrow Night Blue current
![Screenshot from 2024-08-24 18-36-56](https://github.com/user-attachments/assets/a786249c-eba7-406a-8960-05d58e998bd5)

Tomorrow Night Blue fixed
![Screenshot from 2024-08-24 18-37-00](https://github.com/user-attachments/assets/5114d7fe-916b-43dd-a68e-e551d96bb0ad)

