### PR TITLE
fixed wrong highlight color inheritance in Gnome Terminal

### DIFF
--- a/apply-colors.sh
+++ b/apply-colors.sh
@@ -390,6 +390,8 @@ set_theme() {
     if [[ -n "${HIGHLIGHT_FG_COLOR:-}" ]]; then
       dset   highlight-foreground-color  "'${HIGHLIGHT_FG_COLOR}'"
     fi
+  else
+    dset   highlight-colors-set        "false"
   fi
 
   if [[ -n "${BOLD_COLOR:-}" ]]; then


### PR DESCRIPTION
when Gogh creates profiles for Gnome Terminal, it does not set `highlight-colors-set` explicitly. this causes hightlight settings to be inherited from currently selected default profile, cuz Gogh's themes does not (yet) define highlight (even if there is code to support it).

example, "native" (not Gogh's versions) Catppuccin and Nord themes do define highlight settings, Catppuccin is my current default
![Screenshot from 2024-08-26 21-34-23](https://github.com/user-attachments/assets/d073af1c-5eca-4e76-915d-cd165e598701)

now, if i use Gogh to install eg Tomorrow Night Eighties, then highlight is copied from Catppuccin
![Screenshot from 2024-08-26 21-36-58](https://github.com/user-attachments/assets/ea36a3e9-1e17-46cd-b0bd-efdb3d9f57a5)

but the proper look (without highlight color support in themes) is this
![Screenshot from 2024-08-26 21-40-48](https://github.com/user-attachments/assets/60293d57-ce6b-4315-93db-e4532d491f94)

all in all, it's just 1 line fix :)