### PR TITLE
Swapped Kanagawa's White and Bright White colors since they are mismatched

### DIFF
--- a/themes/Kanagawa.yml
+++ b/themes/Kanagawa.yml
@@ -10,7 +10,7 @@ color_04: '#C0A36E'    # Yellow (Command second)
 color_05: '#7E9CD8'    # Blue (Path)
 color_06: '#957FB8'    # Magenta (Syntax var)
 color_07: '#6A9589'    # Cyan (Prompt)
-color_08: '#DCD7BA'    # White
+color_08: '#C8C093'    # White
 
 color_09: '#727169'    # Bright Black
 color_10: '#E82424'    # Bright Red (Command error)
@@ -19,7 +19,7 @@ color_12: '#E6C384'    # Bright Yellow
 color_13: '#7FB4CA'    # Bright Blue (Folder)
 color_14: '#938AA9'    # Bright Magenta
 color_15: '#7AA89F'    # Bright Cyan
-color_16: '#C8C093'    # Bright White
+color_16: '#DCD7BA'    # Bright White
 
 background: '#1F1F28'  # Background
 foreground: '#DCD7BA'  # Foreground (Text)


### PR DESCRIPTION
Here is current White(1) and Bright White(2) colors. As you can see "white" is brighter than "bright white".
![2024-10-02-200618_hyprshot](https://github.com/user-attachments/assets/e6159681-0fce-4238-b6e6-5b01da620ebf)
![2024-10-02-200602_hyprshot](https://github.com/user-attachments/assets/0bdc7996-98c4-4669-ae3f-a6e31d6140d0)


 