### PR TITLE
dracula: Add bright colors

### DIFF
--- a/themes/Dracula.yml
+++ b/themes/Dracula.yml
@@ -1,27 +1,27 @@
 ---
 name: 'Dracula'
-author: ''             # 'AUTHOR NAME (http://WEBSITE.com)'
-variant: ''            # dark or light
+author: 'Dracula (https://draculatheme.com)' # 'AUTHOR NAME (http://WEBSITE.com)'
+variant: 'dark'                              # dark or light
 
 color_01: '#44475A'    # Black (Host)
 color_02: '#FF5555'    # Red (Syntax string)
 color_03: '#50FA7B'    # Green (Command)
-color_04: '#FFB86C'    # Yellow (Command second)
-color_05: '#8BE9FD'    # Blue (Path)
+color_04: '#F1FA8C'    # Yellow (Command second)
+color_05: '#80BFFF'    # Blue (Path)
 color_06: '#BD93F9'    # Magenta (Syntax var)
-color_07: '#FF79C6'    # Cyan (Prompt)
-color_08: '#f8f8f2'    # White
+color_07: '#8BE9FD'    # Cyan (Prompt)
+color_08: '#F8F8F2'    # White
 
-color_09: '#000000'    # Bright Black
-color_10: '#FF5555'    # Bright Red (Command error)
-color_11: '#50FA7B'    # Bright Green (Exec)
-color_12: '#FFB86C'    # Bright Yellow
-color_13: '#8BE9FD'    # Bright Blue (Folder)
-color_14: '#BD93F9'    # Bright Magenta
-color_15: '#FF79C6'    # Bright Cyan
+color_09: '#1E2029'    # Bright Black
+color_10: '#F28C8C'    # Bright Red (Command error)
+color_11: '#A3F5B8'    # Bright Green (Exec)
+color_12: '#EEF5A3'    # Bright Yellow
+color_13: '#A3CCF5'    # Bright Blue (Folder)
+color_14: '#F5A3D2'    # Bright Magenta
+color_15: '#BAEDF7'    # Bright Cyan
 color_16: '#FFFFFF'    # Bright White
 
 background: '#282A36'  # Background
-foreground: '#f8f8f2'  # Foreground (Text)
+foreground: '#F8F8F2'  # Foreground (Text)
 
-cursor: '#f8f8f2'      # Cursor
+cursor: '#F8F8F2'      # Cursor


### PR DESCRIPTION
This change adds some of the bright colors for the Dracula theme so that they're not they aren't the same shades.

These values are copied from the Base24 Dracula scheme at https://github.com/tinted-theming/schemes/blob/spec-0.11/base24/dracula.yaml

Doesn't rebuild the scripts at all, as I didn't know how to do such a thing.