### PR TITLE
Add Punk, Punk Bg and Vaporwave Control Room themes

### DIFF
--- a/themes/Punk Bg.yml
+++ b/themes/Punk Bg.yml
@@ -1,0 +1,26 @@
+---
+name: 'Punk Bg'
+author: 'Alex Bachlej (https://alexbachlej.com)'
+variant: 'Dark'
+
+color_01: '#2E3436'
+color_02: '#FD3057'
+color_03: '#970230'
+color_04: '#C4A000'
+color_05: '#3465A4'
+color_06: '#510A34'
+color_07: '#076A7F'
+color_08: '#D3D7CF'
+
+color_09: '#555753'
+color_10: '#AD0B44'
+color_11: '#F63D5C'
+color_12: '#FCE94F'
+color_13: '#66BABC'
+color_14: '#921E65'
+color_15: '#51AAC8'
+color_16: '#EEEEEC'
+
+background: '#0E051F'
+foreground: '#B8E5EA'
+cursor: '#3F0A29'

--- a/themes/Punk.yml
+++ b/themes/Punk.yml
@@ -1,0 +1,26 @@
+---
+name: 'Punk'
+author: 'Alex Bachlej (https://alexbachlej.com)'
+variant: 'Dark'
+
+color_01: '#2E3436'
+color_02: '#FD3057'
+color_03: '#970230'
+color_04: '#C4A000'
+color_05: '#70A1E0'
+color_06: '#510A34'
+color_07: '#076A7F'
+color_08: '#D3D7CF'
+
+color_09: '#555753'
+color_10: '#AD0B44'
+color_11: '#F63D5C'
+color_12: '#FCE94F'
+color_13: '#4C8B8C'
+color_14: '#921E65'
+color_15: '#51AAC8'
+color_16: '#EEEEEC'
+
+background: '#0C031F'
+foreground: '#E9FDFF'
+cursor: '#E01A4F'

--- a/themes/Vaporwave Control Room.yml
+++ b/themes/Vaporwave Control Room.yml
@@ -1,0 +1,26 @@
+---
+name: 'Vaporwave Control Room'
+author: 'Alex Bachlej (https://alexbachlej.com)'
+variant: 'Light'
+
+color_01: '#393552'
+color_02: '#EB6F92'
+color_03: '#70EAFF'
+color_04: '#F6C177'
+color_05: '#3A8EB1'
+color_06: '#C4A7E7'
+color_07: '#EA9A97'
+color_08: '#E0DEF4'
+
+color_09: '#6E6A86'
+color_10: '#EB6F92'
+color_11: '#50FA7B'
+color_12: '#F6C177'
+color_13: '#73EAFF'
+color_14: '#C4A7E7'
+color_15: '#EA9A97'
+color_16: '#E0DEF4'
+
+background: '#EB64B9'
+foreground: '#F5F4FD'
+cursor: '#E0DEF4'


### PR DESCRIPTION
Adds three original terminal color schemes by Alex Bachlej: Punk, Punk Bg, and Vaporwave Control Room. All three were created and tested in GNOME Terminal and converted to Gogh's theme format.